### PR TITLE
CMake Module: Simpler White Space Trim

### DIFF
--- a/scripts/FindADIOS.cmake
+++ b/scripts/FindADIOS.cmake
@@ -133,20 +133,17 @@ endif(ADIOS_CONFIG)
 if(ADIOS_FOUND)
     execute_process(COMMAND ${ADIOS_CONFIG} ${OPTLIST}
                     OUTPUT_VARIABLE ADIOS_LINKFLAGS
-                    RESULT_VARIABLE ADIOS_CONFIG_RETURN)
+                    RESULT_VARIABLE ADIOS_CONFIG_RETURN
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT ADIOS_CONFIG_RETURN EQUAL 0)
         set(ADIOS_FOUND FALSE)
         message(STATUS "Can NOT execute 'adios_config' - check file permissions")
-    else()
-        # trim trailing newlines
-        string(REGEX REPLACE "(\r?\n)+$" "" ADIOS_LINKFLAGS "${ADIOS_LINKFLAGS}")
     endif()
 
     # find ADIOS_ROOT_DIR
     execute_process(COMMAND ${ADIOS_CONFIG} -d
-                    OUTPUT_VARIABLE ADIOS_ROOT_DIR)
-    # trim trailing newlines
-    string(REGEX REPLACE "(\r?\n)+$" "" ADIOS_ROOT_DIR "${ADIOS_ROOT_DIR}")
+                    OUTPUT_VARIABLE ADIOS_ROOT_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT IS_DIRECTORY "${ADIOS_ROOT_DIR}")
         set(ADIOS_FOUND FALSE)
         message(STATUS "The directory provided by 'adios_config -d' does not exist: ${ADIOS_ROOT_DIR}")
@@ -211,9 +208,8 @@ if(ADIOS_FOUND)
 
     # add the version string
     execute_process(COMMAND ${ADIOS_CONFIG} -v
-                    OUTPUT_VARIABLE ADIOS_VERSION)
-    # trim trailing newlines
-    string(REGEX REPLACE "(\r?\n)+$" "" ADIOS_VERSION "${ADIOS_VERSION}")
+                    OUTPUT_VARIABLE ADIOS_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     
 endif(ADIOS_FOUND)
 


### PR DESCRIPTION
Proposed changes from
  https://github.com/ComputationalRadiationPhysics/picongpu/pull/406
to upstream developers of ADIOS.

Uses the option `OUTPUT_STRIP_TRAILING_WHITESPACE` in `execute_process`.

Related to #7.
