### PR TITLE
Fixed issue trying to set CMAKE_INSTALL_PREFIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@ link_directories(${PROJECT_BINARY_DIR})
 
 #set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
-set(CMAKE_INSTALL_PREFIX $ENV{INSTALL_PREFIX} CACHE PATH "Prefix prepended to install directories" FORCE)
+if(NOT CMAKE_INSTALL_PREFIX)
+  # if CMAKE_INSTALL_PREFIX isn't set, try to get it from the INSTALL_PREFIX environment variable
+  set(CMAKE_INSTALL_PREFIX $ENV{INSTALL_PREFIX} CACHE PATH "Prefix prepended to install directories" FORCE)
+endif()
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${prefix})
 set(bindir ${exec_prefix}/bin)


### PR DESCRIPTION
The only way to set the install directory for ADIOS was by creating
an INSTALL_PREFIX environment variable. The CMake variable would get cleared out
if that value wasn't set. This change checks first to see if CMAKE_INSTALL_PREFIX
is set before trying to get the environment variable value to set as
CMAKE_INSTALL_PREFIX.
