### PR TITLE
only replace @VAR@ in adios_config.flags.in and adios_config.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1806,10 +1806,10 @@ string(REGEX REPLACE ";" " " ADIOSREADLIB_SEQ_LDADD_M "${ADIOSREADLIB_SEQ_LDADD}
 string(REGEX REPLACE ";" " " ADIOSLIB_SEQ_LDADD_M "${ADIOSLIB_SEQ_LDADD}")
 string(REGEX REPLACE ";" " " ADIOSLIB_INT_LDADD_M "${ADIOSLIB_INT_LDADD}")
 
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/adios_config.flags.cmake ${CMAKE_CURRENT_BINARY_DIR}/adios_config.flags)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/adios_config.flags.cmake ${CMAKE_CURRENT_BINARY_DIR}/adios_config.flags @ONLY)
 #####################end of processing adios_config.flags.in #####################
 #####################start processing adios_config.flags.in #####################
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/adios_config.in ${CMAKE_CURRENT_BINARY_DIR}/adios_config)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/adios_config.in ${CMAKE_CURRENT_BINARY_DIR}/adios_config @ONLY)
 #####################end of processing adios_config.flags.in #####################
 install(FILES ${CMAKE_BINARY_DIR}/adios_config.flags DESTINATION ${sysconfdir})
 install(PROGRAMS ${CMAKE_BINARY_DIR}/adios_config DESTINATION ${bindir})


### PR DESCRIPTION
do NOT replace ${VAR}, but only @VAR@ in adios_config.flags.in and adios_config.in
@ONLY is already part of CMake 2.8: http://www.cmake.org/cmake/help/v2.8.0/cmake.html#command:configure_file