### PR TITLE
Zlib: Zero Read - Assert only on >0

### DIFF
--- a/src/transforms/adios_transform_zlib_read.c
+++ b/src/transforms/adios_transform_zlib_read.c
@@ -40,7 +40,8 @@ int adios_transform_zlib_generate_read_subrequests(adios_transform_read_request 
                                                     adios_transform_pg_read_request *pg_reqgroup)
 {
     void *buf = malloc(pg_reqgroup->raw_var_length);
-    assert(buf);
+    if(pg_reqgroup->raw_var_length > 0)
+        assert(buf);
     adios_transform_raw_read_request *subreq = adios_transform_raw_read_request_new_whole_pg(pg_reqgroup, buf);
     adios_transform_raw_read_request_append(pg_reqgroup, subreq);
     return 0;


### PR DESCRIPTION
Reads for zero length will also result in a zero raw size.
Found during restart/checkpoint reads with [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu).

Regarding runtime errors of the form
```
  transforms/adios_transform_zlib_read.c:43:
    adios_transform_zlib_generate_read_subrequests:
    Assertion `buf' failed.
```

nevertheless, it seems that `raw_var_length` is not initialized correctly (random value) and the error resides a bit deeper, probably in `src/core/transforms/adios_transforms_read.c` -> `generate_read_request_for_pg()`.

Full [code example](https://github.com/ax3l/picongpu/blob/5ad03ad2b21cfab52fdcf93dfbc5db1cfdc106c1/src/picongpu/include/plugins/adios/restart/LoadParticleAttributesFromADIOS.hpp#L75-L106).