### PR TITLE
Python3: gcc fixes / linter / config

### DIFF
--- a/utils/gpp/ad_config.py
+++ b/utils/gpp/ad_config.py
@@ -11,7 +11,7 @@ class adiosConfig:
         doc = xml.dom.minidom.parse (config_file_name)
         nodes = doc.childNodes
         if (nodes.length != 1):
-            print 'malformed adios config file, should contain only a single adios-config element'
+            print('malformed adios config file, should contain only a single adios-config element')
             raise SystemExit
         self.config_node = nodes[0]
 
@@ -41,7 +41,7 @@ class adiosConfig:
 
     def get_buffer (self):
         #return the buffer info
-        print 'get_buffer is not yet implemented'
+        print('get_buffer is not yet implemented')
 
     def get_host_language (self):
         return self.config_node.getAttribute ('host-language')
@@ -65,7 +65,7 @@ class adiosGroup:
             if node.localName == 'var':
                 newvar = var (node, self, self.time_index)
                 self.vars.append (newvar)
-                #print 'Add to dict local var ['+newvar.get_fullpath()+']'
+                #print('Add to dict local var ['+newvar.get_fullpath()+']')
                 self.vardict [newvar.get_fullpath()] = newvar
                 self.vars_and_gwrites_and_attrs.append (newvar)
             #elif node.localName == 'attribute':
@@ -79,7 +79,7 @@ class adiosGroup:
                     if gb_node.localName == 'var':
                         newvar = var (gb_node, self, self.time_index)
                         self.vars.append (newvar)
-                        #print 'Add to dict global var ['+newvar.get_fullpath()+']'
+                        #print('Add to dict global var ['+newvar.get_fullpath()+']')
                         self.vardict [newvar.get_fullpath()] = newvar
                         self.vars_and_gwrites_and_attrs.append (newvar)
                     elif gb_node.localName == 'gwrite':
@@ -102,8 +102,8 @@ class adiosGroup:
 
     # Returns the variable from this group with the specified name, or None
     def get_var (self, varfullpath):
-        #print '          get_var('+varfullpath+')'
-        if self.vardict.has_key (varfullpath):
+        #print('          get_var('+varfullpath+')')
+        if varfullpath in self.vardict:
             return self.vardict [varfullpath]
 
         return None
@@ -184,10 +184,10 @@ class var:
             # place the dimensions in a list and remove the time-index if it is there.
             dims = filter (lambda x : x != self.time_index, self.var_node.getAttribute ('dimensions').split(',') )
             cleandims = []
-            #print '       get_dimensions of var '+self.get_fullpath()
+            #print('       get_dimensions of var '+self.get_fullpath())
             for d in dims:
 
-                #print '          dim "'+str(d)+'"'
+                #print('          dim "'+str(d)+'"')
                 if d.isdigit():
                     cleandims.append (d)
                     continue
@@ -196,10 +196,10 @@ class var:
                 # for that variable
                 dim_var = self.get_group().get_var (d)				
                 if dim_var != None:
-                    #print '            dim var found, get name...'
+                    #print('            dim var found, get name...')
                     d = dim_var.get_gwrite()
                 #else:
-                    #print '            dim var NOT found'
+                    #print('            dim var NOT found')
                     
 
                 cleandims.append (d)

--- a/utils/gpp/gpp.py.in
+++ b/utils/gpp/gpp.py.in
@@ -22,10 +22,10 @@ def checkXML (config_file, path):
     if rv == 0:
         return 'success'
     elif rv == 32512:  # System unable to find adios_lint command
-        print "Unable to find adios_lint. Proceeding with code generation"
+        print("Unable to find adios_lint. Proceeding with code generation.")
         return 'success'
     else:
-        print "gpp.py failed."
+        print("gpp.py failed.")
         return 'failure'
 
 
@@ -58,11 +58,11 @@ def get_c_groupsize_code (group):
 
 
 def get_fortran_groupsize_code (group):
-    #print 'Get Fortran Groupsize code for group "'+group.get_name()+'"'
+    #print('Get Fortran Groupsize code for group "'+group.get_name()+'"')
     groupsize_code_string = ''
     groupsize_code_string += 'adios_groupsize = '
     for v in group.get_vars():
-        #print '  count variable "'+v.get_fullpath()+'"'
+        #print('  count variable "'+v.get_fullpath()+'"')
         if (v.is_scalar() ):
             if v.get_type() != 'string':
                 groupsize_code_string += ('%d' % type_mapper.get_size (v.get_type() ) + ' &\n                + ')
@@ -72,7 +72,7 @@ def get_fortran_groupsize_code (group):
             groupsize_code_string += ('%d * ' % type_mapper.get_size (v.get_type() ) )
 
             for d in v.get_dimensions():
-                #print '  count dim "'+d+'"'
+                #print('  count dim "'+d+'"')
                 # need to check whether this is the timestep
                 groupsize_code_string += '(' + d + ') * '
 
@@ -85,7 +85,7 @@ def get_fortran_groupsize_code (group):
 
     groupsize_code_string += '\ncall adios_group_size (adios_handle, adios_groupsize, adios_totalsize, adios_err)'
 
-    #print 'Done Fortran Groupsize'
+    #print('Done Fortran Groupsize')
     return groupsize_code_string;
 
 
@@ -215,7 +215,7 @@ def generate_fortran (config):
 
 
 def generate_c (config):
-    #print "c"
+    #print("c")
 
     # Output a gwrite_*.ch file for each group in the config
     for group in config.get_groups():
@@ -247,7 +247,7 @@ def main (argv=None):
   
     # Must be called with one argument, the name of the xml file
     if len (sys.argv) != 2:
-        print 'Usage: gpp.py <config file>\n'
+        print('Usage: gpp.py <config file>\n')
         return 1
 
 
@@ -268,7 +268,7 @@ def main (argv=None):
     elif lang == 'c' or lang == 'cpp':
         generate_c (config)
     else:
-        print "Fatal: Language unknown or unspecified"
+        print("Fatal: Language unknown or unspecified")
         raise SystemExit
 
 


### PR DESCRIPTION
Fixes show-stoppers in python scripts that prevent install on python3 only systems.

Fixes mainly `print()` calls.

This change is fully python2 compatible.
  https://stackoverflow.com/questions/13415181/brackets-around-print-in-python/13415304#13415304

First seen with automates testing in
  https://travis-ci.org/ComputationalRadiationPhysics/pyDive/jobs/101651336