### PR TITLE
bpmeta: Fix missing `-pthread` linker dependency

### DIFF
--- a/utils/bpmeta/CMakeLists.txt
+++ b/utils/bpmeta/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/public)
 link_directories(${PROJECT_BINARY_DIR}/src)
 
 add_executable(bpmeta bpmeta.c)
-target_link_libraries(bpmeta adios_internal_nompi ${ADIOSLIB_INT_LDADD})
+target_link_libraries(bpmeta adios_internal_nompi ${ADIOSLIB_INT_LDADD} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(bpmeta PROPERTIES COMPILE_FLAGS "${ADIOSLIB_EXTRA_CPPFLAGS} ${ADIOSLIB_INT_CPPFLAGS} ${ADIOSLIB_INT_CFLAGS}")
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/utils/bpmeta/bpmeta DESTINATION ${bindir})

--- a/utils/bpmeta/Makefile.am
+++ b/utils/bpmeta/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = bpmeta
 
 bpmeta_SOURCES = bpmeta.c
 bpmeta_CPPFLAGS = $(AM_CPPFLAGS) $(ADIOSLIB_EXTRA_CPPFLAGS) $(ADIOSLIB_INT_CPPFLAGS) $(ADIOSLIB_INT_CFLAGS)
-bpmeta_LDFLAGS = $(ADIOSLIB_INT_LDFLAGS)
+bpmeta_LDFLAGS = $(ADIOSLIB_INT_LDFLAGS) $(PTHREAD_LIBS)
 bpmeta_LDADD = $(top_builddir)/src/libadios_internal_nompi.a
 bpmeta_LDADD += $(ADIOSLIB_INT_LDADD)
 


### PR DESCRIPTION
@pnorbert `bpmeta` is a threaded tool and failed the `make` build target in its linker step on most Linux systems I used it so far (Debian, Ubunty, Rhea, ...).

This added dependency fixes it.