### PR TITLE
Fix automake (README)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,3 +87,5 @@ adios_config adios_config.flags: Makefile
 adios_config: adios_config.makesrc adios_config.flags
 adios_config.flags: adios_config.flags.makesrc
 
+README: README.md
+	cat $< > $@.tmp


### PR DESCRIPTION
Renaming of the README did have a side effect on
./autogen.sh since autotools expect an actual README file.

This fixes https://github.com/ornladios/ADIOS/pull/76, similar as proposed in
  http://stackoverflow.com/questions/15013672/use-autotools-with-readme-md

@pnorbert sorry, that's a bit awkward :D CI will protect us in the future from my stupidity