### PR TITLE
autogen.sh: add shebang

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 aclocal -I config
 libtoolize --force --copy
 autoconf


### PR DESCRIPTION
add the missing shebang in a portable way to `autogen.sh`