### PR TITLE
fix warning `implicit declaration ... function "exit"`

### DIFF
--- a/tests/suite/programs/adios_amr_write.c
+++ b/tests/suite/programs/adios_amr_write.c
@@ -14,6 +14,7 @@
 */
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "adios.h"
 int main (int argc, char ** argv) 
 {

--- a/tests/suite/programs/adios_amr_write_2vars.c
+++ b/tests/suite/programs/adios_amr_write_2vars.c
@@ -14,6 +14,7 @@
 */
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "adios.h"
 int main (int argc, char ** argv) 
 {


### PR DESCRIPTION
add missing include to fix the warning `incompatible implicit declaration of built-in function ‘exit’`