### PR TITLE
fix warning `redefine strndup`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1218,6 +1218,9 @@ CHECK_FUNCTION_EXISTS(strncpy HAVE_STRNCPY)
 # Define to 1 if you have the `strdup' function.
 CHECK_FUNCTION_EXISTS(strdup HAVE_STRDUP)
 
+# Define to 1 if you have the `strndup' function.
+CHECK_FUNCTION_EXISTS(strndup HAVE_STRNDUP)
+
 # Define to 1 if you have the `snprintf' function.
 CHECK_FUNCTION_EXISTS(snprintf HAVE_SNPRINTF)
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -251,9 +251,10 @@
 /* Define to 1 if you have the <string.h> header file. */
 #cmakedefine HAVE_STRING_H 1
 
-/*  to 1 if you have the `strncpy' function. */
+/*  to 1 if you have the `strncpy` function. */
 #cmakedefine HAVE_STRNCPY 1
 #cmakedefine HAVE_STRDUP 1
+#cmakedefine HAVE_STRNDUP 1
 #cmakedefine HAVE_SNPRINTF 1
 #cmakedefine HAVE_VSNPRINTF 1
 #cmakedefine HAVE_LONG_LONG 1

--- a/tests/C/flexpath_tests/global_range_select/CMakeLists.txt.orig
+++ b/tests/C/flexpath_tests/global_range_select/CMakeLists.txt.orig
@@ -1,0 +1,25 @@
+include_directories(${PROJECT_SOURCE_DIR}/src/public)
+include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/test/C/flexpath_tests/include)
+include_directories(${PROJECT_BINARY_DIR}/src/public)
+link_directories(${PROJECT_SOURCE_DIR}/src)
+link_directories(${PROJECT_BINARY_DIR}/src)
+
+
+<<<<<<< bd72262bb89b1bbd8ece53de2004f77b69137b01
+add_executable(writer writer.c)
+target_link_libraries(writer adios ${ADIOSLIB_LDADD} ${MPI_C_LIBRARIES}) 
+
+add_executable(reader reader.c)
+target_link_libraries(reader adios ${ADIOSLIB_LDADD} ${MPI_C_LIBRARIES})
+=======
+add_executable(arrays_writer writer.c)
+set_target_properties(arrays_writer PROPERTIES COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS}")
+target_link_libraries(arrays_writer adios ${ADIOSLIB_LDADD} ${MPI_C_LIBRARIES}) 
+
+add_executable(arrays_reader reader.c)
+set_target_properties(arrays_reader PROPERTIES COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS}")
+target_link_libraries(arrays_reader adios ${ADIOSLIB_LDADD} ${MPI_C_LIBRARIES})
+>>>>>>> fix cmake compile
+
+file(COPY arrays.xml DESTINATION ${PROJECT_BINARY_DIR}/tests/C/flexpath_tests/global_range_select)

--- a/utils/bpls/CMakeLists.txt
+++ b/utils/bpls/CMakeLists.txt
@@ -8,6 +8,7 @@ link_directories(${PROJECT_BINARY_DIR}/utils/bpls)
 add_executable(bpls bpls.c)
 target_link_libraries(bpls adiosread_nompi ${ADIOSREADLIB_SEQ_LDADD})
 set_target_properties(bpls PROPERTIES COMPILE_FLAGS "${ADIOSLIB_EXTRA_CPPFLAGS} ${ADIOSREADLIB_SEQ_CPPFLAGS} ${ADIOSREADLIB_SEQ_CFLAGS}")
+target_include_directories(bpls PRIVATE "${PROJECT_BINARY_DIR}")
 
 #install(FILES bpls.h DESTINATION ${PROJECT_BINARY_DIR}/utils/bpls)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/utils/bpls/bpls DESTINATION ${bindir})

--- a/utils/bpls/bpls.h
+++ b/utils/bpls/bpls.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include "adios_read.h"
+#include "config.h"
 
 /* definitions for bpls.c */
 #define myfree(p) if (p) { free(p); p=NULL; }

--- a/utils/skeldump/skeldump.h
+++ b/utils/skeldump/skeldump.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 #include "adios_read.h"
+#include "config.h"
 
 /* definitions for skeldump.c */
 #define myfree(p) if (p) { free(p); p=NULL; }


### PR DESCRIPTION
- config.h.cmake: add `HAVE_STRNDUP`
- CMake: add check for `HAVE_STRNDUP`
- add missing include "config.h"
- bpls: add missing include directory

warning:
```C++
adios/utils/skeldump/skeldump.h:23:0: warning: "strndup" redefined
 #  define strndup(str,len) strdup(str)
```

- [x] test build cmake (no Fortran)
- [x] teat build configure