### PR TITLE
Missing timer stop for adios_group_size()

### DIFF
--- a/src/core/common_adios.c
+++ b/src/core/common_adios.c
@@ -473,6 +473,7 @@ int common_adios_group_size(int64_t fd_p, uint64_t data_size,
 
   if (fd->buffer_size == 0) {
     *total_size = 0;
+    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, *total_size);
     return err_no_error;
   }
 


### PR DESCRIPTION
I missed one "return" statement for issuing an exit event for adios_group_size().