### PR TITLE
Complete the callback support for full API

### DIFF
--- a/src/core/a2sel.c
+++ b/src/core/a2sel.c
@@ -12,11 +12,13 @@
 
 #include "public/adios_error.h"
 #include "core/a2sel.h"
+#include "core/adiost_callback_internal.h"
 
 extern int adios_errno;
 
 ADIOS_SELECTION * a2sel_boundingbox (int ndim, const uint64_t *start, const uint64_t *count)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_selection_boundingbox, ndim, start, count, NULL);
     adios_errno = err_no_error;
     ADIOS_SELECTION * sel = (ADIOS_SELECTION *) malloc (sizeof(ADIOS_SELECTION));
     if (sel) {
@@ -29,12 +31,14 @@ ADIOS_SELECTION * a2sel_boundingbox (int ndim, const uint64_t *start, const uint
     } else {
         adios_error(err_no_memory, "Cannot allocate memory for bounding box selection\n");
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_selection_boundingbox, ndim, start, count, sel);
     return sel;
 }
 
 ADIOS_SELECTION * a2sel_points (int ndim, uint64_t npoints, const uint64_t *points,
                                 ADIOS_SELECTION * container, int free_points_on_delete)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_selection_points, ndim, npoints, points, container, free_points_on_delete, NULL);
     adios_errno = err_no_error;
     ADIOS_SELECTION * sel = (ADIOS_SELECTION *) malloc (sizeof(ADIOS_SELECTION));
     if (sel) {
@@ -47,11 +51,13 @@ ADIOS_SELECTION * a2sel_points (int ndim, uint64_t npoints, const uint64_t *poin
     } else {
         adios_error(err_no_memory, "Cannot allocate memory for points selection\n");
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_selection_points, ndim, npoints, points, container, free_points_on_delete, sel);
     return sel;
 }
 
 ADIOS_SELECTION * a2sel_writeblock (int index)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_selection_writeblock, index, NULL);
     adios_errno = err_no_error;
     ADIOS_SELECTION * sel = (ADIOS_SELECTION *) malloc (sizeof(ADIOS_SELECTION));
     if (sel) {
@@ -65,11 +71,13 @@ ADIOS_SELECTION * a2sel_writeblock (int index)
     } else {
         adios_error(err_no_memory, "Cannot allocate memory for writeblock selection\n");
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_selection_writeblock, index, sel);
     return sel;
 }
 
 ADIOS_SELECTION * a2sel_auto (char *hints)
 {
+    ADIOST_CALLBACK_EXIT(adiost_event_selection_auto, hints, NULL);
     adios_errno = err_no_error;
     ADIOS_SELECTION * sel = (ADIOS_SELECTION *) malloc (sizeof(ADIOS_SELECTION));
     if (sel) {
@@ -78,11 +86,13 @@ ADIOS_SELECTION * a2sel_auto (char *hints)
     } else {
         adios_error(err_no_memory, "Cannot allocate memory for auto selection\n");
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_selection_auto, hints, sel);
     return sel;
 }
 
 void a2sel_free (ADIOS_SELECTION *sel)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_selection_delete, sel);
     if (!sel)
         return;
     if (sel->type == ADIOS_SELECTION_POINTS)
@@ -109,6 +119,7 @@ void a2sel_free (ADIOS_SELECTION *sel)
         }
     }
     free(sel);
+    ADIOST_CALLBACK_EXIT(adiost_event_selection_delete, sel);
 }
 
 ADIOS_SELECTION * a2sel_copy (const ADIOS_SELECTION * sel)

--- a/src/core/adios.c
+++ b/src/core/adios.c
@@ -31,6 +31,8 @@
 #include "dmalloc.h"
 #endif
 
+#include "adiost_callback_internal.h"
+
 extern struct adios_transport_struct * adios_transports;
 extern int adios_errno;
 
@@ -74,8 +76,10 @@ int adios_allocate_buffer (enum ADIOS_BUFFER_ALLOC_WHEN adios_buffer_alloc_when
 ///////////////////////////////////////////////////////////////////////////////
 void adios_set_max_buffer_size (uint64_t max_buffer_size_MB)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_set_max_buffer_size, max_buffer_size_MB);
     if (max_buffer_size_MB > 0)
         adios_databuffer_set_max_size (max_buffer_size_MB * 1024L * 1024L);
+    ADIOST_CALLBACK_EXIT(adiost_event_set_max_buffer_size, max_buffer_size_MB);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -348,6 +352,7 @@ int adios_delete_vardefs (int64_t id)
 // It is simply the product of local dimensions and byte-size of type
 uint64_t adios_expected_var_size (int64_t var_id)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_expected_var_size, var_id);
     adios_errno = err_no_error;
     uint64_t size = 0;
     if (var_id != 0) {
@@ -386,6 +391,7 @@ uint64_t adios_expected_var_size (int64_t var_id)
         adios_error (err_invalid_varid, "%s called with invalid variable ID\n", __func__);
     }
 
+    ADIOST_CALLBACK_EXIT(adiost_event_expected_var_size, var_id);
     return size;
 }
 

--- a/src/core/adios_internals.c
+++ b/src/core/adios_internals.c
@@ -38,6 +38,8 @@
 #include "core/transforms/adios_transforms_write.h"
 #include "core/transforms/adios_transforms_specparse.h"
 
+#include "adiost_callback_internal.h"
+
 struct adios_method_list_struct * adios_methods = 0;
 struct adios_group_list_struct * adios_groups = 0;
 
@@ -994,6 +996,7 @@ int adios_common_define_attribute (int64_t group, const char * name
         ,const char * var
         )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_attribute, group, name, path, type, value, var);
     struct adios_group_struct * g = (struct adios_group_struct *) group;
     struct adios_attribute_struct * attr = (struct adios_attribute_struct *)
         malloc (sizeof (struct adios_attribute_struct));
@@ -1016,6 +1019,7 @@ int adios_common_define_attribute (int64_t group, const char * name
             free (attr->path);
             free (attr);
 
+            ADIOST_CALLBACK_EXIT(adiost_event_define_attribute, group, name, path, type, value, var);
             return 0;
         }
         attr->type = type;
@@ -1036,6 +1040,7 @@ int adios_common_define_attribute (int64_t group, const char * name
             free (attr->path);
             free (attr);
 
+            ADIOST_CALLBACK_EXIT(adiost_event_define_attribute, group, name, path, type, value, var);
             return 0;
         }
     }
@@ -1057,6 +1062,7 @@ int adios_common_define_attribute (int64_t group, const char * name
             free (attr->path);
             free (attr);
 
+            ADIOST_CALLBACK_EXIT(adiost_event_define_attribute, group, name, path, type, value, var);
             return 0;
         }
     }
@@ -1067,6 +1073,7 @@ int adios_common_define_attribute (int64_t group, const char * name
 
     adios_append_attribute (&g->attributes, attr, ++g->member_count);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_attribute, group, name, path, type, value, var);
     return 1;
 }
 
@@ -1079,6 +1086,7 @@ int adios_common_define_attribute_byvalue (int64_t group, const char * name
         ,const void * values
         )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_attribute_byvalue, group, name, path, type, nelems, values);
     struct adios_group_struct * g = (struct adios_group_struct *) group;
     struct adios_attribute_struct * attr = (struct adios_attribute_struct *)
         malloc (sizeof (struct adios_attribute_struct));
@@ -1093,6 +1101,7 @@ int adios_common_define_attribute_byvalue (int64_t group, const char * name
                     "type attribute\n",
                     name);
             free (attr);
+            ADIOST_CALLBACK_EXIT(adiost_event_define_attribute_byvalue, group, name, path, type, nelems, values);
             return 0;
         }
         attr->type = type;
@@ -1109,6 +1118,7 @@ int adios_common_define_attribute_byvalue (int64_t group, const char * name
                             "Not enough memory to copy string array attribute %s/%s\n", 
                             path, name);
                     free (attr);
+                    ADIOST_CALLBACK_EXIT(adiost_event_define_attribute_byvalue, group, name, path, type, nelems, values);
                     return 0;
                 }
                 attr->data_size = total_length;
@@ -1138,6 +1148,7 @@ int adios_common_define_attribute_byvalue (int64_t group, const char * name
                     "value attribute\n", name);
             free (attr->value);
             free (attr);
+            ADIOST_CALLBACK_EXIT(adiost_event_define_attribute_byvalue, group, name, path, type, nelems, values);
             return 0;
         }
         attr->name = strdup (name);
@@ -1149,6 +1160,7 @@ int adios_common_define_attribute_byvalue (int64_t group, const char * name
                 "Attribute element %s has invalid "
                 "value attribute\n", name);
         free (attr);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_attribute_byvalue, group, name, path, type, nelems, values);
         return 0;
     }
 
@@ -1157,6 +1169,7 @@ int adios_common_define_attribute_byvalue (int64_t group, const char * name
 
     adios_append_attribute (&g->attributes, attr, ++g->member_count);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_attribute_byvalue, group, name, path, type, nelems, values);
     return 1;
 }
 
@@ -1388,6 +1401,7 @@ int adios_common_declare_group (int64_t * id, const char * name
         ,enum ADIOS_STATISTICS_FLAG stats
         )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_declare_group, id, name, time_index_name, stats);
     struct adios_group_struct * g = (struct adios_group_struct *)
         malloc (sizeof (struct adios_group_struct));
 
@@ -1437,6 +1451,7 @@ int adios_common_declare_group (int64_t * id, const char * name
 
     adios_append_group (g);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_declare_group, id, name, time_index_name, stats);
     return 1;
 }
 
@@ -1893,6 +1908,7 @@ int64_t adios_common_define_var (int64_t group_id, const char * name
         ,const char * local_offsets
         )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var, group_id, name, path, type, dimensions, global_dimensions, local_offsets);
     struct adios_group_struct * t = (struct adios_group_struct *) group_id;
     struct adios_var_struct * v = (struct adios_var_struct *)
         malloc (sizeof (struct adios_var_struct));
@@ -2004,6 +2020,7 @@ int64_t adios_common_define_var (int64_t group_id, const char * name
                 adios_error (err_no_memory,
                         "config.xml: out of memory in adios_common_define_var\n");
 
+                ADIOST_CALLBACK_EXIT(adiost_event_define_var, group_id, name, path, type, dimensions, global_dimensions, local_offsets);
                 return 0;
             }
             char * dim = 0;
@@ -2029,6 +2046,7 @@ int64_t adios_common_define_var (int64_t group_id, const char * name
                 a2s_cleanup_dimensions (g_dim_tokens, g_dim_count);
                 a2s_cleanup_dimensions (lo_dim_tokens, lo_dim_count);
 
+                ADIOST_CALLBACK_EXIT(adiost_event_define_var, group_id, name, path, type, dimensions, global_dimensions, local_offsets);
                 return 0;
             }
 
@@ -2051,12 +2069,14 @@ int64_t adios_common_define_var (int64_t group_id, const char * name
     v->id = ++t->member_count;
     adios_append_var (t, v);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var, group_id, name, path, type, dimensions, global_dimensions, local_offsets);
     return (int64_t)v;
 }
 
 /* Set the transformation method for a variable. Only one transformation will work for each variable */
 int adios_common_set_transform (int64_t var_id, const char *transform_type_str)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_set_transform, var_id, transform_type_str);
     struct adios_var_struct * v = (struct adios_var_struct *)var_id;
     assert (v);
     // NCSU ALACRITY-ADIOS - parse transform type string, and call the transform layer to
@@ -2072,6 +2092,7 @@ int adios_common_set_transform (int64_t var_id, const char *transform_type_str)
     // This function sets the transform_type field. It does nothing if transform_type is none.
     // Note: ownership of the transform_spec struct is given to this function
     v = adios_transform_define_var(v);
+    ADIOST_CALLBACK_EXIT(adiost_event_set_transform, var_id, transform_type_str);
     return adios_errno;
 }
 
@@ -6295,6 +6316,7 @@ int queue_dequeue (Queue * queue, void ** data)
 // Functions for non-XML API fo ADIOS Schema some of which are also called from functions in adios_internals_mxml.c
 int adios_common_define_schema_version (struct adios_group_struct * new_group, char * schema_version)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_schema_version, (int64_t)new_group, schema_version);
     int64_t p_new_group = (int64_t) new_group;
 
     if (strcasecmp (schema_version,"")){
@@ -6336,6 +6358,7 @@ int adios_common_define_schema_version (struct adios_group_struct * new_group, c
         }
         free(ver);
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_define_schema_version, (int64_t)new_group, schema_version);
     return 0;
 }
 
@@ -6347,6 +6370,7 @@ int adios_common_define_mesh_timeSeriesFormat (const char * timeseries,
                                                const char * name
                                               )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_timeseriesformat, timeseries, (int64_t)new_group, name);
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
     char * format_att_nam = 0;     // extension format .xxxx att name
@@ -6357,6 +6381,7 @@ int adios_common_define_mesh_timeSeriesFormat (const char * timeseries,
     // varname.XXXX.png where XXXX is the time step padded with 0s
     // We do not fail if this is not given as variables all have nsteps
     if (!timeseries || !strcmp(timeseries,"")){
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timeseriesformat, timeseries, (int64_t)new_group, name);
         return 1;
     }
 
@@ -6372,6 +6397,7 @@ int adios_common_define_mesh_timeSeriesFormat (const char * timeseries,
         free(format_att_val);
     }
     free (d1);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timeseriesformat, timeseries, (int64_t)new_group, name);
     return 1;
 }
 
@@ -6381,6 +6407,7 @@ int adios_common_define_mesh_timeScale (const char * timescale,
                                         const char * name
                                        )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_timescale, timescale, (int64_t)new_group, name);
     char * c;                      // comma location
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
@@ -6412,6 +6439,7 @@ int adios_common_define_mesh_timeScale (const char * timescale,
        */
     if (!timescale || !strcmp(timescale,"")){
 //        printf("time-scale attribute for mesh: %s not provided.\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timescale, timescale, (int64_t)new_group, name);
         return 1;
     }
 
@@ -6435,6 +6463,7 @@ int adios_common_define_mesh_timeScale (const char * timescale,
                           c, name);
                 free (d1);
 
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timescale, timescale, (int64_t)new_group, name);
                 return 0;
 
             }else{
@@ -6542,11 +6571,13 @@ int adios_common_define_mesh_timeScale (const char * timescale,
     }else{
         printf("Error: time format not recognized.\nPlease check documentation for time formatting.\n");
         free(d1);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timescale, timescale, (int64_t)new_group, name);
         return 0;
     }
 
     free (d1);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timescale, timescale, (int64_t)new_group, name);
     return 1;
 }
 
@@ -6568,6 +6599,7 @@ int adios_common_define_mesh_timeSteps (const char * timesteps,
                                         const char * name
                                        )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_timesteps, timesteps, (int64_t)new_group, name);
     char * c;                      // comma location
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
@@ -6599,6 +6631,7 @@ int adios_common_define_mesh_timeSteps (const char * timesteps,
        */
     if (!timesteps || !strcmp(timesteps,"")){
 //        printf("time-steps for mesh %s attribute not provided.\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timesteps, timesteps, (int64_t)new_group, name);
         return 1;
     }
 
@@ -6619,6 +6652,7 @@ int adios_common_define_mesh_timeSteps (const char * timesteps,
                           c, name);
                 free (d1);
 
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timesteps, timesteps, (int64_t)new_group, name);
                 return 0;
 
             }else{
@@ -6715,11 +6749,13 @@ int adios_common_define_mesh_timeSteps (const char * timesteps,
     }else{
         printf("Error: time format not recognized.\nPlease check documentation for time formatting.\n");
         free(d1);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timesteps, timesteps, (int64_t)new_group, name);
         return 0;
     }
 
     free (d1);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_timesteps, timesteps, (int64_t)new_group, name);
     return 1;
 }
 
@@ -6734,6 +6770,7 @@ int adios_common_define_mesh_uniform (char * dimensions,
                                       int64_t group_id
                                      )
 {   
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_uniform, dimensions, origin, spacing, maximum, nspace, group_id, name);
     struct adios_group_struct * new_group = (struct adios_group_struct *) group_id;
     char * mpath = 0;
     mpath = malloc(strlen("/adios_schema/")+strlen(name)+strlen("/type")+1);
@@ -6742,8 +6779,10 @@ int adios_common_define_mesh_uniform (char * dimensions,
     strcat (mpath, "/type");
     adios_common_define_attribute (group_id, mpath, "", adios_string, "uniform", "");
 
-    if (!adios_define_mesh_uniform_dimensions (dimensions, new_group, name))
+    if (!adios_define_mesh_uniform_dimensions (dimensions, new_group, name)) {
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_uniform, dimensions, origin, spacing, maximum, nspace, group_id, name);
         return 1;
+    }
 
     adios_define_mesh_uniform_origins (origin, new_group, name);
     
@@ -6754,6 +6793,7 @@ int adios_common_define_mesh_uniform (char * dimensions,
     adios_define_mesh_nspace (nspace, new_group, name);
 
     free (mpath);   
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_uniform, dimensions, origin, spacing, maximum, nspace, group_id, name);
     return 0;
 }
 
@@ -6766,6 +6806,7 @@ int adios_common_define_mesh_rectilinear (char * dimensions,
                                           int64_t group_id
                                          )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_rectilinear, dimensions, coordinates, nspace, group_id, name);
     struct adios_group_struct * new_group = (struct adios_group_struct *) group_id;
     char * mpath = 0;
     mpath = malloc(strlen("/adios_schema/")+strlen(name)+strlen("/type")+1);
@@ -6774,26 +6815,33 @@ int adios_common_define_mesh_rectilinear (char * dimensions,
     strcat (mpath, "/type");
     adios_common_define_attribute (group_id, mpath, "", adios_string, "rectilinear", "");
 
-    if (!adios_define_mesh_rectilinear_dimensions (dimensions, new_group, name))
+    if (!adios_define_mesh_rectilinear_dimensions (dimensions, new_group, name)) {
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_rectilinear, dimensions, coordinates, nspace, group_id, name);
         return 1;
+	}
 
     // Determine if it is the multi-var or single-var case
     char *p;
     // If we do not find "," in the coordinates
     if (!(p = strstr(coordinates, ",")))
     {
-        if (!adios_define_mesh_rectilinear_coordinatesSingleVar (coordinates, new_group, name))
+        if (!adios_define_mesh_rectilinear_coordinatesSingleVar (coordinates, new_group, name)) {
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_rectilinear, dimensions, coordinates, nspace, group_id, name);
             return 1;
+		}
     }
     else
     {
-        if (!adios_define_mesh_rectilinear_coordinatesMultiVar (coordinates, new_group, name))
+        if (!adios_define_mesh_rectilinear_coordinatesMultiVar (coordinates, new_group, name)) {
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_rectilinear, dimensions, coordinates, nspace, group_id, name);
             return 1;
+		}
     }
 
     adios_define_mesh_nspace (nspace, new_group, name);
 
     free (mpath);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_rectilinear, dimensions, coordinates, nspace, group_id, name);
     return 0;
 }
 
@@ -6806,6 +6854,7 @@ int adios_common_define_mesh_structured (char * dimensions,
                                          int64_t group_id
                                         )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
     struct adios_group_struct * new_group = (struct adios_group_struct *) group_id;
     char * mpath = 0;
     mpath = malloc(strlen("/adios_schema/")+strlen(name)+strlen("/type")+1);
@@ -6815,36 +6864,46 @@ int adios_common_define_mesh_structured (char * dimensions,
     adios_common_define_attribute (group_id, mpath, "", adios_string, "structured", "");
 
     if (dimensions){
-        if (!adios_define_mesh_structured_dimensions (dimensions, new_group, name))
+        if (!adios_define_mesh_structured_dimensions (dimensions, new_group, name)) {
+		    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
             return 0;
+		}
     }else{
         log_warn ("config.xml: value attribute on "
                   "dimensions required (%s)\n", name);
-
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
         return 0;
     }
 
     if (nspace){
-//        if (!adios_define_mesh_structured_nspace (nspace, new_group, name))
-          if (!adios_define_mesh_nspace (nspace, new_group, name))
+//      if (!adios_define_mesh_structured_nspace (nspace, new_group, name))
+        if (!adios_define_mesh_nspace (nspace, new_group, name)) {
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
             return 0;
+		}
     }
     if (points){
         char *p;
         // If we do find "," in points (single-var case)
         if (!(p = strstr(points, ","))){
-            if (!adios_define_mesh_structured_pointsSingleVar (points, new_group, name))
+            if (!adios_define_mesh_structured_pointsSingleVar (points, new_group, name)) {
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
                 return 0;
+			}
         }else{
-            if (!adios_define_mesh_structured_pointsMultiVar (points, new_group, name))
+            if (!adios_define_mesh_structured_pointsMultiVar (points, new_group, name)) {
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
                 return 0;
+			}
         }
     }else{
         log_warn ("config.xml: value on "
                   "points required for mesh type=structured (%s)\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
         return 0;
     }
     free (mpath);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_structured, dimensions, points, nspace, group_id, name);
     return 1;
 }
 
@@ -6858,6 +6917,7 @@ int adios_common_define_mesh_unstructured (char * points,
                                            const char * name,
                                            int64_t group_id)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
     struct adios_group_struct * new_group = (struct adios_group_struct *) group_id;
     char * mpath = 0;
     mpath = malloc(strlen("/adios_schema/")+strlen(name)+strlen("/type")+1);
@@ -6868,45 +6928,57 @@ int adios_common_define_mesh_unstructured (char * points,
     if (nspace && *nspace != 0)
     {
 //        if (!adios_define_mesh_unstructured_nspace (nspace, new_group, name))
-            if (!adios_define_mesh_nspace (nspace, new_group, name))
-            return 0;
+            if (!adios_define_mesh_nspace (nspace, new_group, name)) {
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
+                return 0;
+			}
     }
     if (npoints && *npoints != 0)
     {
-        if (!adios_define_mesh_unstructured_npoints (npoints, new_group, name))
+        if (!adios_define_mesh_unstructured_npoints (npoints, new_group, name)) {
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
+		}
 
     }
     if (points && *points != 0){
         char *p;
         // If we do find "," in points (single-var case)
         if (!(p = strstr(points, ","))){
-            if (!adios_define_mesh_unstructured_pointsSingleVar (points, new_group, name))
+            if (!adios_define_mesh_unstructured_pointsSingleVar (points, new_group, name)) {
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
                 return 0;
+			}
         }else{
-            if (!adios_define_mesh_unstructured_pointsMultiVar (points, new_group, name))
+            if (!adios_define_mesh_unstructured_pointsMultiVar (points, new_group, name)) {
+                ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
                 return 0;
+			}
         }
     }else{
         log_warn ("config.xml: value on "
                   "points required for mesh type=structured (%s)\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
         return 0;
     }
     if (!data){
         log_warn ("config.xml: data attribute on "
                   "uniform-cells required (%s)\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
         return 0;
     }
     if (!count) 
     {
         log_warn ("config.xml: count attribute on "
                   "uniform-cells required (%s)\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
         return 0;
     }
     if (!type)
     {
         log_warn ("config.xml: type attribute on "
                   "uniform-cells required (%s)\n", name);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
         return 0;
     }
     char *pt;
@@ -6915,35 +6987,44 @@ int adios_common_define_mesh_unstructured (char * points,
         if ( (pt = strstr(count,",")) ){
             log_warn ("count value on uniform-cells (check data value)"
                       " should not contain ',' (%s)\n",name);
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
         }
         if ( (pt = strstr(type,",")) ){
             log_warn ("type value on uniform-cells (check data value)"
                       " should not contain ',' (%s)\n", name);
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
         }
         if (!adios_define_mesh_unstructured_uniformCells (count, data, type
                     , new_group
                     ,name
                     )
-           )
+           ) {
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
+		}
         // Mixed cells calse
     }else{
         if (!(pt = strstr(count,","))){
             log_warn ("count value on mixed-cells (check data value)"
                       " should contain ',' (%s)\n", name);
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
         }
         if (!(pt = strstr(type,","))){
             log_warn ("type value on mixed-cells (check data value)"
                       " should contain ',' (%s)\n", name);
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
         }
         if (!adios_define_mesh_unstructured_mixedCells (count, data, type
-                    , new_group, name))
+                    , new_group, name)) {
+            ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
             return 0;
+		}
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_unstructured, points, data, count, type, npoints, nspace, group_id, name);
     return 1;
 }
 
@@ -7073,6 +7154,7 @@ int adios_common_define_var_timesteps (const char * timesteps,
                                        const char * path
                                       )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var_timesteps, timesteps, (int64_t)new_group, name);
     char * c;                      // comma location
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
@@ -7103,6 +7185,7 @@ int adios_common_define_var_timesteps (const char * timesteps,
        in ADIOS_inq_var = # of times the var was written
        */
     if (!timesteps || !strcmp(timesteps,"")){
+        ADIOST_CALLBACK_EXIT(adiost_event_define_var_timesteps, timesteps, p_new_group, name);
         return 1;
     }
 
@@ -7123,6 +7206,7 @@ int adios_common_define_var_timesteps (const char * timesteps,
                           c, name);
                 free (d1);
 
+                ADIOST_CALLBACK_EXIT(adiost_event_define_var_timesteps, timesteps, p_new_group, name);
                 return 0;
 
             }else{
@@ -7219,11 +7303,13 @@ int adios_common_define_var_timesteps (const char * timesteps,
     }else{
         printf("Error: time format not recognized.\nPlease check documentation for time formatting.\n");
         free(d1);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_var_timesteps, timesteps, p_new_group, name);
         return 0;
     }
 
     free (d1);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var_timesteps, timesteps, p_new_group, name);
     return 1;
 }
 
@@ -7234,6 +7320,7 @@ int adios_common_define_var_timeseriesformat (const char * timeseries,
                                               const char * path
                                              )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var_timeseriesformat, timeseries, (int64_t)new_group, name);
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
     char * format_att_nam = 0;     // extension format .xxxx att name
@@ -7244,6 +7331,7 @@ int adios_common_define_var_timeseriesformat (const char * timeseries,
     // varname.XXXX.png where XXXX is the time step padded with 0s
     // We do not fail if this is not given as variables all have nsteps
     if (!timeseries || !strcmp(timeseries,"")){
+         ADIOST_CALLBACK_EXIT(adiost_event_define_var_timeseriesformat, timeseries, p_new_group, name);
         return 1;
     }
 
@@ -7257,6 +7345,7 @@ int adios_common_define_var_timeseriesformat (const char * timeseries,
         free(format_att_val);
     }
     free (d1);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var_timeseriesformat, timeseries, p_new_group, name);
     return 1;
 }
 
@@ -7267,6 +7356,7 @@ int adios_common_define_var_timescale (const char * timescale,
                                        const char * path
                                       )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var_timescale, timescale, (int64_t)new_group, name);
     char * c;                      // comma location
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
@@ -7298,6 +7388,7 @@ int adios_common_define_var_timescale (const char * timescale,
        in ADIOS_inq_var = # of times the var was written
        */
     if (!timescale || !strcmp(timescale,"")){
+        ADIOST_CALLBACK_EXIT(adiost_event_define_var_timescale, timescale, p_new_group, name);
         return 1;
     }
 
@@ -7322,6 +7413,7 @@ int adios_common_define_var_timescale (const char * timescale,
                           c, name);
                 free (d1);
 
+                ADIOST_CALLBACK_EXIT(adiost_event_define_var_timescale, timescale, p_new_group, name);
                 return 0;
 
             }else{
@@ -7431,11 +7523,13 @@ int adios_common_define_var_timescale (const char * timescale,
     }else{
         printf("Error: time format not recognized.\nPlease check documentation for time formatting.\n");
         free(d1);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_var_timescale, timescale, p_new_group, name);
         return 0;
     }
 
     free (d1);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var_timescale, timescale, p_new_group, name);
     return 1;
 }
 
@@ -7445,6 +7539,7 @@ int adios_common_define_var_hyperslab ( const char * hyperslab,
                                         const char * name,
                                         const char * path)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var_hyperslab, hyperslab, (int64_t)new_group, name);
     char * c;                      // comma location
     char * d1;                     // save of strdup
     int64_t p_new_group = (int64_t) new_group;
@@ -7475,6 +7570,7 @@ int adios_common_define_var_hyperslab ( const char * hyperslab,
        in ADIOS_inq_var = # of times the var was written
        */
     if (!hyperslab || !strcmp(hyperslab,"")){
+        ADIOST_CALLBACK_EXIT(adiost_event_define_var_hyperslab, hyperslab, p_new_group, name);
         return 1;
     }
 
@@ -7534,11 +7630,13 @@ int adios_common_define_var_hyperslab ( const char * hyperslab,
     }else{
         printf("Error: hyperslab format not recognized.\nPlease check documentation for hyperslab formatting.\n");
         free(d1);
+        ADIOST_CALLBACK_EXIT(adiost_event_define_var_hyperslab, hyperslab, p_new_group, name);
         return 0;
     }
 
     free (d1);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var_hyperslab, hyperslab, p_new_group, name);
     return 1;
 
 }
@@ -8383,28 +8481,33 @@ int adios_define_mesh_unstructured_mixedCells (const char * count,
 // called by NO-XML API
 int adios_common_define_var_mesh (int64_t group_id, const char * varname, const char * meshname, const char * path)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var_mesh, group_id, varname, meshname);
     char *mpath = 0;
     mpath = malloc(strlen("/adios_schema")+strlen(varname)+1);
     strcpy(mpath,varname);
     strcat(mpath,"/adios_schema");
     adios_common_define_attribute (group_id, mpath, path, adios_string, meshname, "");
     free (mpath);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var_mesh, group_id, varname, meshname);
     return 0;
 }
 
 int adios_common_define_var_centering (int64_t group_id, const char * varname, const char * centering, const char * path)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_var_centering, group_id, varname, centering);
     char *mpath = 0;
     mpath = malloc(strlen("/adios_schema/centering")+strlen(varname)+1);
     strcpy(mpath,varname);
     strcat(mpath,"/adios_schema/centering");
     adios_common_define_attribute (group_id, mpath, path, adios_string, centering, "");
     free (mpath);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_var_centering, group_id, varname, centering);
     return 0;
 }
 
 int adios_common_define_mesh_group (int64_t group_id, const char * name, const char * group)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_group, group, group_id, name);
     char * mpath = 0;
     mpath = malloc(strlen("/adios_schema/")+strlen(name)+strlen("/mesh-group")+1);
     strcpy (mpath, "/adios_schema/");
@@ -8413,10 +8516,12 @@ int adios_common_define_mesh_group (int64_t group_id, const char * name, const c
 //    adios_conca_mesh_att_nam(&group, name, "mesh-group");
     adios_common_define_attribute (group_id, mpath, "", adios_string, group, "");
     free (mpath);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_group, group, group_id, name);
     return 0;
 }
 
 int adios_common_define_mesh_file (int64_t group_id, char * name, char * file){
+    ADIOST_CALLBACK_ENTER(adiost_event_define_mesh_file, group_id, name, file);
     char * mpath = 0;
     mpath = malloc(strlen("/adios_schema/")+strlen(name)+strlen("/mesh-file")+1);
     strcpy (mpath, "/adios_schema/");
@@ -8424,6 +8529,7 @@ int adios_common_define_mesh_file (int64_t group_id, char * name, char * file){
     strcat (mpath, "/mesh-file");
     adios_common_define_attribute (group_id, mpath, "", adios_string, file, "");
     free (mpath);
+    ADIOST_CALLBACK_EXIT(adiost_event_define_mesh_file, group_id, name, file);
     return 0;
 }
 

--- a/src/core/adios_internals_mxml.c
+++ b/src/core/adios_internals_mxml.c
@@ -29,6 +29,8 @@
 #include "dmalloc.h"
 #endif
 
+#include "adiost_callback_internal.h"
+
 static enum ADIOS_FLAG adios_host_language_fortran = adios_flag_yes;
 // NCSU ALACRITY-ADIOS: Need these to be extern so they can be accessed by both adios_internals.c and here
 extern struct adios_method_list_struct * adios_methods;
@@ -2580,6 +2582,7 @@ int adios_common_select_method_by_group_id (int priority, const char * method
         ,const char * base_path, int iters
         )
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_select_method, group_id, method, parameters, base_path);
     struct adios_group_struct * g;
     struct adios_method_struct * new_method;
     int requires_group_comm = 0;
@@ -2621,6 +2624,7 @@ int adios_common_select_method_by_group_id (int priority, const char * method
         free (new_method->parameters);
         free (new_method);
 
+        ADIOST_CALLBACK_EXIT(adiost_event_select_method, group_id, method, parameters, base_path);
         return 0;
     }
 
@@ -2636,6 +2640,7 @@ int adios_common_select_method_by_group_id (int priority, const char * method
         free (new_method->parameters);
         free (new_method);
 
+        ADIOST_CALLBACK_EXIT(adiost_event_select_method, group_id, method, parameters, base_path);
         return 0;
     }
     else
@@ -2653,6 +2658,7 @@ int adios_common_select_method_by_group_id (int priority, const char * method
             free (new_method->parameters);
             free (new_method);
 
+            ADIOST_CALLBACK_EXIT(adiost_event_select_method, group_id, method, parameters, base_path);
             return 0;
         }
         adios_add_method_to_group (&g->methods, new_method);
@@ -2661,6 +2667,7 @@ int adios_common_select_method_by_group_id (int priority, const char * method
 
     adios_append_method (new_method);
 
+    ADIOST_CALLBACK_EXIT(adiost_event_select_method, group_id, method, parameters, base_path);
     return 1;
 }
 

--- a/src/core/adiost_callback_internal.c
+++ b/src/core/adiost_callback_internal.c
@@ -183,3 +183,60 @@ static adiost_interface_fn_t adiost_fn_lookup(const char *s)
     return (adiost_interface_fn_t) 0;
 }
 
+char * adiost_build_dimension_string(struct adios_var_struct *v, int * ndims) { 
+    // I hate to use a fixed length string, but...
+    char tmpstr[1024] = {0};
+    *ndims = 0;
+    if (v->dimensions == NULL) {
+        return strdup("");
+    }
+    char dims[256] = {0};
+    char global_dims[256] = {0};
+    char local_offsets[256] = {0};
+    struct adios_dimension_struct * tmp = v->dimensions;
+    char delimiter = '[';
+    while (tmp != NULL) {
+        *ndims = *ndims + 1;
+        // just a regular old number? Get its value.
+        if (tmp->dimension.rank > 0) {
+            sprintf(dims, "%s%c%lu", dims, delimiter, tmp->dimension.rank);
+        // another ADIOS variable? Get its name.
+        } else if (tmp->dimension.var != NULL) {
+            sprintf(dims, "%s%c%s", dims, delimiter, tmp->dimension.var->name);
+        // another ADIOS attribute? Get its name.
+        } else if (tmp->dimension.attr != NULL) {
+            sprintf(dims, "%s%c%s", dims, delimiter, tmp->dimension.attr->name);
+        }
+        // just a regular old number? Get its value.
+        if (tmp->global_dimension.rank > 0) {
+            sprintf(global_dims, "%s%c%lu", global_dims, delimiter, tmp->global_dimension.rank);
+        // another ADIOS variable? Get its name.
+        } else if (tmp->global_dimension.var != NULL) {
+            sprintf(global_dims, "%s%c%s", global_dims, delimiter, tmp->global_dimension.var->name);
+        // another ADIOS attribute? Get its name.
+        } else if (tmp->global_dimension.attr != NULL) {
+            sprintf(global_dims, "%s%c%s", global_dims, delimiter, tmp->global_dimension.attr->name);
+        }
+        // just a regular old number? Get its value.
+        if (tmp->local_offset.rank > 0) {
+            sprintf(local_offsets, "%s%c%lu", local_offsets, delimiter, tmp->local_offset.rank);
+        // another ADIOS variable? Get its name.
+        } else if (tmp->local_offset.var != NULL) {
+            sprintf(local_offsets, "%s%c%s", local_offsets, delimiter, tmp->local_offset.var->name);
+        // another ADIOS attribute? Get its name.
+        } else if (tmp->local_offset.attr != NULL) {
+            sprintf(local_offsets, "%s%c%s", local_offsets, delimiter, tmp->local_offset.attr->name);
+        }
+        // move on to the next dimension?
+        delimiter = ',';
+        tmp = tmp->next;
+    }
+    delimiter = ']';
+    sprintf(dims, "%s%c", dims, delimiter);
+    sprintf(global_dims, "%s%c", global_dims, delimiter);
+    sprintf(local_offsets, "%s%c", local_offsets, delimiter);
+    // build the whole thing
+    sprintf(tmpstr, "%s;%s;%s", dims, global_dims, local_offsets);
+    return strdup(tmpstr);
+}
+

--- a/src/core/adiost_callback_internal.h
+++ b/src/core/adiost_callback_internal.h
@@ -22,6 +22,7 @@
 #define ADIOST_EXPORT __attribute__((visibility("default")))
 #define ADIOST_WEAK __attribute__ (( weak )) 
 #include "public/adiost_callback_api.h"
+#include "adios_internals.h"
 
 /* Definitions */
 
@@ -57,6 +58,7 @@ extern adiost_callbacks_t adiost_callbacks;
 void adiost_pre_init(void);
 void adiost_post_init(void);
 void adiost_finalize(void);
+char * adiost_build_dimension_string(struct adios_var_struct *v, int * ndims);
 
 /* These variadic macros save us from having to add 4+ lines of source code
  * each time that we want to make an event callback. */
@@ -80,6 +82,24 @@ void adiost_finalize(void);
         adiost_callbacks.adiost_callback(__event)) { \
           adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
             adiost_event_exit, ##__VA_ARGS__); \
+    } \
+
+#define ADIOST_CALLBACK_WRITE_ENTER(__event, __fd, __v) \
+    if (adios_tool_enabled && \
+        adiost_callbacks.adiost_callback(__event)) { \
+          int __ndims = 0; \
+          char * __tmp = adiost_build_dimension_string(__v, &__ndims); \
+          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
+            adiost_event_enter, __v->name, __v->type, __ndims, __tmp, __v->data); \
+    } \
+
+#define ADIOST_CALLBACK_WRITE_EXIT(__event, __fd, __v) \
+    if (adios_tool_enabled && \
+        adiost_callbacks.adiost_callback(__event)) { \
+          int __ndims = 0; \
+          char * __tmp = adiost_build_dimension_string(__v, &__ndims); \
+          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
+            adiost_event_exit, __v->name, __v->type, __ndims, __tmp, __v->data); \
     } \
 
 #endif // #ifndef __ADIOST_CALLBACK_INTERNAL_H__

--- a/src/core/adiost_callback_internal.h
+++ b/src/core/adiost_callback_internal.h
@@ -63,24 +63,24 @@ char * adiost_build_dimension_string(struct adios_var_struct *v, int * ndims);
 /* These variadic macros save us from having to add 4+ lines of source code
  * each time that we want to make an event callback. */
 
-#define ADIOST_CALLBACK(__event, __fd, ...) \
+#define ADIOST_CALLBACK(__event, ...) \
     if (adios_tool_enabled && \
         adiost_callbacks.adiost_callback(__event)) { \
-          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
+          adiost_callbacks.adiost_callback(__event)( \
             adiost_event, ##__VA_ARGS__); \
     } \
 
-#define ADIOST_CALLBACK_ENTER(__event, __fd, ...) \
+#define ADIOST_CALLBACK_ENTER(__event, ...) \
     if (adios_tool_enabled && \
         adiost_callbacks.adiost_callback(__event)) { \
-          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
+          adiost_callbacks.adiost_callback(__event)( \
             adiost_event_enter, ##__VA_ARGS__); \
     } \
 
-#define ADIOST_CALLBACK_EXIT(__event, __fd, ...) \
+#define ADIOST_CALLBACK_EXIT(__event, ...) \
     if (adios_tool_enabled && \
         adiost_callbacks.adiost_callback(__event)) { \
-          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
+          adiost_callbacks.adiost_callback(__event)( \
             adiost_event_exit, ##__VA_ARGS__); \
     } \
 
@@ -89,8 +89,8 @@ char * adiost_build_dimension_string(struct adios_var_struct *v, int * ndims);
         adiost_callbacks.adiost_callback(__event)) { \
           int __ndims = 0; \
           char * __tmp = adiost_build_dimension_string(__v, &__ndims); \
-          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
-            adiost_event_enter, __v->name, __v->type, __ndims, __tmp, __v->data); \
+          adiost_callbacks.adiost_callback(__event)(adiost_event_enter, (int64_t)__fd, \
+            __v->name, __v->type, __ndims, __tmp, __v->data); \
     } \
 
 #define ADIOST_CALLBACK_WRITE_EXIT(__event, __fd, __v) \
@@ -98,8 +98,8 @@ char * adiost_build_dimension_string(struct adios_var_struct *v, int * ndims);
         adiost_callbacks.adiost_callback(__event)) { \
           int __ndims = 0; \
           char * __tmp = adiost_build_dimension_string(__v, &__ndims); \
-          adiost_callbacks.adiost_callback(__event)((int64_t)__fd, \
-            adiost_event_exit, __v->name, __v->type, __ndims, __tmp, __v->data); \
+          adiost_callbacks.adiost_callback(__event)(adiost_event_exit, (int64_t)__fd, \
+            __v->name, __v->type, __ndims, __tmp, __v->data); \
     } \
 
 #endif // #ifndef __ADIOST_CALLBACK_INTERNAL_H__

--- a/src/core/adiost_default_tool.c
+++ b/src/core/adiost_default_tool.c
@@ -122,7 +122,7 @@ void __timer_stop(adiost_timer_index_t index) {
     adiost_timers_count[index] = adiost_timers_count[index] + 1;
 }
 
-ADIOST_EXTERN void my_thread(int64_t file_descriptor, char * name, adiost_event_type_t type) {
+ADIOST_EXTERN void my_thread(adiost_event_type_t type, int64_t file_descriptor, char * name) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -132,7 +132,7 @@ ADIOST_EXTERN void my_thread(int64_t file_descriptor, char * name, adiost_event_
     }
 }
 
-ADIOST_EXTERN void my_open ( int64_t file_descriptor, adiost_event_type_t type,
+ADIOST_EXTERN void my_open ( adiost_event_type_t type, int64_t file_descriptor,
     const char * group_name, const char * file_name, const char * mode) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
@@ -147,7 +147,7 @@ ADIOST_EXTERN void my_open ( int64_t file_descriptor, adiost_event_type_t type,
     }
 }
 
-ADIOST_EXTERN void my_close(int64_t file_descriptor, adiost_event_type_t type) {
+ADIOST_EXTERN void my_close(adiost_event_type_t type, int64_t file_descriptor) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -158,7 +158,7 @@ ADIOST_EXTERN void my_close(int64_t file_descriptor, adiost_event_type_t type) {
     }
 }
 
-ADIOST_EXTERN void my_write( int64_t file_descriptor, adiost_event_type_t type, const char * name, enum ADIOS_DATATYPES data_type, const int ndims, const char * dims, const void * value) {
+ADIOST_EXTERN void my_write( adiost_event_type_t type, int64_t file_descriptor, const char * name, enum ADIOS_DATATYPES data_type, const int ndims, const char * dims, const void * value) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -168,7 +168,7 @@ ADIOST_EXTERN void my_write( int64_t file_descriptor, adiost_event_type_t type, 
     }
 } 
 
-ADIOST_EXTERN void my_read( int64_t file_descriptor, adiost_event_type_t type) {
+ADIOST_EXTERN void my_read( adiost_event_type_t type, int64_t file_descriptor ) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -178,8 +178,8 @@ ADIOST_EXTERN void my_read( int64_t file_descriptor, adiost_event_type_t type) {
     }
 } 
 
-ADIOST_EXTERN void my_advance_step( int64_t file_descriptor,
-    adiost_event_type_t type) {
+ADIOST_EXTERN void my_advance_step( adiost_event_type_t type,
+    int64_t file_descriptor) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -189,8 +189,8 @@ ADIOST_EXTERN void my_advance_step( int64_t file_descriptor,
     }
 } 
 
-ADIOST_EXTERN void my_group_size(int64_t file_descriptor, 
-    adiost_event_type_t type, uint64_t data_size, uint64_t total_size) {
+ADIOST_EXTERN void my_group_size( adiost_event_type_t type, 
+    int64_t file_descriptor, uint64_t data_size, uint64_t total_size) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -210,8 +210,8 @@ ADIOST_EXTERN void my_group_size(int64_t file_descriptor,
     }
 } 
 
-ADIOST_EXTERN void my_transform( int64_t file_descriptor,
-        adiost_event_type_t type) {
+ADIOST_EXTERN void my_transform( adiost_event_type_t type,
+    int64_t file_descriptor) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -221,8 +221,8 @@ ADIOST_EXTERN void my_transform( int64_t file_descriptor,
     }
 } 
 
-ADIOST_EXTERN void my_fp_send_read_msg(int64_t file_descriptor,
-        adiost_event_type_t type) { 
+ADIOST_EXTERN void my_fp_send_read_msg(adiost_event_type_t type, 
+    int64_t file_descriptor) { 
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -232,8 +232,8 @@ ADIOST_EXTERN void my_fp_send_read_msg(int64_t file_descriptor,
     }
 } 
 
-ADIOST_EXTERN void my_fp_send_finalize_msg(int64_t file_descriptor,
-        adiost_event_type_t type) { 
+ADIOST_EXTERN void my_fp_send_finalize_msg( adiost_event_type_t type,
+    int64_t file_descriptor) { 
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -243,8 +243,8 @@ ADIOST_EXTERN void my_fp_send_finalize_msg(int64_t file_descriptor,
     }
 } 
 
-ADIOST_EXTERN void my_fp_add_var_to_read_msg(int64_t file_descriptor,
-        adiost_event_type_t type) { 
+ADIOST_EXTERN void my_fp_add_var_to_read_msg(adiost_event_type_t type,
+    int64_t file_descriptor) { 
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -254,8 +254,8 @@ ADIOST_EXTERN void my_fp_add_var_to_read_msg(int64_t file_descriptor,
     }
 } 
 
-ADIOST_EXTERN void my_fp_copy_buffer(int64_t file_descriptor,
-        adiost_event_type_t type) { 
+ADIOST_EXTERN void my_fp_copy_buffer(adiost_event_type_t type,
+    int64_t file_descriptor) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
@@ -343,6 +343,6 @@ ADIOST_EXTERN void default_adiost_initialize (adiost_function_lookup_t adiost_fn
 
 /* Weak function definitions, declarations */
 
-extern adiost_initialize_t adiost_tool(void) { return default_adiost_initialize; }
+extern adiost_initialize_t default_adiost_tool(void) { return default_adiost_initialize; }
 
 

--- a/src/core/adiost_default_tool.c
+++ b/src/core/adiost_default_tool.c
@@ -122,12 +122,12 @@ void __timer_stop(adiost_timer_index_t index) {
     adiost_timers_count[index] = adiost_timers_count[index] + 1;
 }
 
-ADIOST_EXTERN void my_thread(adiost_event_type_t type, int64_t file_descriptor, char * name) {
+ADIOST_EXTERN void my_thread(adiost_event_type_t type, int64_t file_descriptor, const char * name) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_thread_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_thread_timer);
     }
 }
@@ -142,7 +142,7 @@ ADIOST_EXTERN void my_open ( adiost_event_type_t type, int64_t file_descriptor,
         debug_print("mode: %s!\n", mode);
         __timer_start(adiost_open_to_close_timer);
         __timer_start(adiost_open_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_open_timer);
     }
 }
@@ -152,28 +152,31 @@ ADIOST_EXTERN void my_close(adiost_event_type_t type, int64_t file_descriptor) {
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_close_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_close_timer);
         __timer_stop(adiost_open_to_close_timer);
     }
 }
 
-ADIOST_EXTERN void my_write( adiost_event_type_t type, int64_t file_descriptor, const char * name, enum ADIOS_DATATYPES data_type, const int ndims, const char * dims, const void * value) {
+ADIOST_EXTERN void my_write( adiost_event_type_t type, int64_t file_descriptor,
+    const char * name, enum ADIOS_DATATYPES data_type, const int ndims, 
+	const char * dims, const void * value) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_write_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_write_timer);
     }
 } 
 
-ADIOST_EXTERN void my_read( adiost_event_type_t type, int64_t file_descriptor ) {
+ADIOST_EXTERN void my_read( adiost_event_type_t type, int64_t file_descriptor,
+    const char * var_name, uint64_t read_size, const void * var) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_read_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_read_timer);
     }
 } 
@@ -184,7 +187,7 @@ ADIOST_EXTERN void my_advance_step( adiost_event_type_t type,
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_advance_step_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_advance_step_timer);
     }
 } 
@@ -195,7 +198,7 @@ ADIOST_EXTERN void my_group_size( adiost_event_type_t type,
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_group_size_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         debug_print("data size: %" PRIu64 "!\n", data_size); fflush(stdout);
         adiost_counters_accumulated[adiost_data_bytes_counter] = 
             adiost_counters_accumulated[adiost_data_bytes_counter] + data_size;
@@ -210,13 +213,12 @@ ADIOST_EXTERN void my_group_size( adiost_event_type_t type,
     }
 } 
 
-ADIOST_EXTERN void my_transform( adiost_event_type_t type,
-    int64_t file_descriptor) {
+ADIOST_EXTERN void my_transform( adiost_event_type_t type, int64_t var_id,
+    const char * transform_type_str) {
     DEBUG_PRINT
-    DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_transform_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_transform_timer);
     }
 } 
@@ -227,7 +229,7 @@ ADIOST_EXTERN void my_fp_send_read_msg(adiost_event_type_t type,
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_fp_send_read_msg_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_fp_send_read_msg_timer);
     }
 } 
@@ -238,7 +240,7 @@ ADIOST_EXTERN void my_fp_send_finalize_msg( adiost_event_type_t type,
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_fp_send_finalize_msg_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_fp_send_finalize_msg_timer);
     }
 } 
@@ -249,7 +251,7 @@ ADIOST_EXTERN void my_fp_add_var_to_read_msg(adiost_event_type_t type,
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_fp_add_var_to_read_msg_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_fp_add_var_to_read_msg_timer);
     }
 } 
@@ -260,7 +262,7 @@ ADIOST_EXTERN void my_fp_copy_buffer(adiost_event_type_t type,
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {
         __timer_start(adiost_fp_copy_buffer_timer);
-    } else {
+    } else if (type == adiost_event_exit) {
         __timer_stop(adiost_fp_copy_buffer_timer);
     }
 } 

--- a/src/core/adiost_default_tool.c
+++ b/src/core/adiost_default_tool.c
@@ -158,7 +158,7 @@ ADIOST_EXTERN void my_close(int64_t file_descriptor, adiost_event_type_t type) {
     }
 }
 
-ADIOST_EXTERN void my_write( int64_t file_descriptor, adiost_event_type_t type) {
+ADIOST_EXTERN void my_write( int64_t file_descriptor, adiost_event_type_t type, const char * name, enum ADIOS_DATATYPES data_type, const int ndims, const char * dims, const void * value) {
     DEBUG_PRINT
     DEBUG_PRINT_FD
     if (type == adiost_event_enter) {

--- a/src/core/common_adios.c
+++ b/src/core/common_adios.c
@@ -56,6 +56,7 @@ int common_adios_init(const char *config, MPI_Comm comm) {
   adiost_pre_init();
   adios_parse_config(config, comm);
   adiost_post_init();
+  ADIOST_CALLBACK(adiost_event_init, config, comm);
   return adios_errno;
 }
 
@@ -67,11 +68,13 @@ int common_adios_init_noxml(MPI_Comm comm) {
   adiost_pre_init();
   adios_local_config(comm);
   adiost_post_init();
+  ADIOST_CALLBACK(adiost_event_init_noxml, comm);
   return adios_errno;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int common_adios_finalize(int mype) {
+  ADIOST_CALLBACK_ENTER(adiost_event_finalize, mype);
   struct adios_method_list_struct *m;
   struct adios_group_list_struct *g;
 
@@ -109,6 +112,7 @@ int common_adios_finalize(int mype) {
   timer_finalize();
 #endif
 
+  ADIOST_CALLBACK_EXIT(adiost_event_finalize, mype);
   adiost_finalize();
   return adios_errno;
 }
@@ -142,7 +146,7 @@ int common_adios_open(int64_t *fd_p, const char *group_name, const char *name,
   timer_start("adios_open_to_close");
   timer_start("adios_open");
 #endif
-  ADIOST_CALLBACK_ENTER(adiost_event_open, *fd_p, group_name, name, file_mode);
+  ADIOST_CALLBACK_ENTER(adiost_event_open, *fd_p, group_name, name, file_mode, comm);
 
   struct adios_group_struct *g = NULL;
   struct adios_method_list_struct *methods = NULL;
@@ -159,7 +163,7 @@ int common_adios_open(int64_t *fd_p, const char *group_name, const char *name,
                 "adios_open: try to open file %s with undefined group: %s\n",
                 name, group_name);
     *fd_p = 0;
-    ADIOST_CALLBACK_EXIT(adiost_event_open, *fd_p, group_name, name, file_mode);
+    ADIOST_CALLBACK_EXIT(adiost_event_open, *fd_p, group_name, name, file_mode, comm);
     return adios_errno;
   }
 
@@ -436,7 +440,7 @@ int common_adios_open(int64_t *fd_p, const char *group_name, const char *name,
 #if defined(WITH_NCSU_TIMER) && defined(TIMER_LEVEL) && (TIMER_LEVEL <= 0)
   timer_stop("adios_open");
 #endif
-  ADIOST_CALLBACK_EXIT(adiost_event_open, *fd_p, group_name, name, file_mode);
+  ADIOST_CALLBACK_EXIT(adiost_event_open, *fd_p, group_name, name, file_mode, comm);
   return adios_errno;
 }
 
@@ -448,7 +452,7 @@ int common_adios_group_size(int64_t fd_p, uint64_t data_size,
   timer_start("adios_group_size");
 #endif
   // printf("enter adios_group_size datasize= %llu\n", data_size);
-  ADIOST_CALLBACK_ENTER(adiost_event_group_size, fd_p, data_size, *total_size);
+  ADIOST_CALLBACK_ENTER(adiost_event_group_size, fd_p, data_size, total_size);
 
   adios_errno = err_no_error;
   struct adios_file_struct *fd;
@@ -457,7 +461,7 @@ int common_adios_group_size(int64_t fd_p, uint64_t data_size,
   if (!fd) {
     adios_error(err_invalid_file_pointer,
                 "Invalid handle passed to adios_group_size\n");
-    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, *total_size);
+    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, total_size);
     return adios_errno;
   }
 
@@ -467,13 +471,13 @@ int common_adios_group_size(int64_t fd_p, uint64_t data_size,
 #if defined(WITH_NCSU_TIMER) && defined(TIMER_LEVEL) && (TIMER_LEVEL <= 0)
     timer_stop("adios_group_size");
 #endif
-    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, *total_size);
+    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, total_size);
     return err_no_error;
   }
 
   if (fd->buffer_size == 0) {
     *total_size = 0;
-    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, *total_size);
+    ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, total_size);
     return err_no_error;
   }
 
@@ -517,7 +521,7 @@ int common_adios_group_size(int64_t fd_p, uint64_t data_size,
   // each var will be added to the buffer by the adios_write calls
   // attributes will be added by adios_close
 
-  ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, *total_size);
+  ADIOST_CALLBACK_EXIT(adiost_event_group_size, fd_p, data_size, total_size);
   return adios_errno;
 }
 
@@ -794,10 +798,10 @@ int common_adios_write_byid(struct adios_file_struct *fd,
                             struct adios_var_struct *v, const void *var) {
   struct adios_method_list_struct *m = fd->group->methods;
 
-  ADIOST_CALLBACK_WRITE_ENTER(adiost_event_write, fd, v);
+  ADIOST_CALLBACK_WRITE_ENTER(adiost_event_write_byid, fd, v);
   adios_errno = err_no_error;
   if (m && m->next == NULL && m->method->m == ADIOS_METHOD_NULL) {
-    ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
+    ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write_byid, fd, v);
     return adios_errno;
   }
 
@@ -834,7 +838,7 @@ int common_adios_write_byid(struct adios_file_struct *fd,
               err_no_memory,
               "In adios_write, cannot allocate %lld bytes to copy scalar %s\n",
               element_size, v->name);
-          ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
+          ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write_byid, fd, v);
           return adios_errno;
         }
 
@@ -849,7 +853,7 @@ int common_adios_write_byid(struct adios_file_struct *fd,
               err_no_memory,
               "In adios_write, cannot allocate %lld bytes to copy string %s\n",
               element_size, v->name);
-          ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
+          ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write_byid, fd, v);
           return adios_errno;
         }
         ((char *)v->adata)[element_size] = 0;
@@ -873,7 +877,7 @@ int common_adios_write_byid(struct adios_file_struct *fd,
     adios_copy_var_written(fd, v);
   }
 
-  ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
+  ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write_byid, fd, v);
   return adios_errno;
 }
 
@@ -925,13 +929,13 @@ int common_adios_get_write_buffer(int64_t fd_p, const char *name,
 
 int common_adios_read(int64_t fd_p, const char *name, void *buffer,
                       uint64_t buffer_size) {
-  ADIOST_CALLBACK_ENTER(adiost_event_read, fd_p);
+  ADIOST_CALLBACK_ENTER(adiost_event_read, fd_p, name, buffer, buffer_size);
   struct adios_file_struct *fd = (struct adios_file_struct *)fd_p;
   adios_errno = err_no_error;
   if (!fd) {
     adios_error(err_invalid_file_pointer,
                 "Invalid handle passed to adios_group_size\n");
-    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p);
+    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p, name, buffer, buffer_size);
 
     return adios_errno;
   }
@@ -940,7 +944,7 @@ int common_adios_read(int64_t fd_p, const char *name, void *buffer,
 
   if (m && m->next == NULL && m->method->m == ADIOS_METHOD_NULL) {
     // nothing to do so just return
-    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p);
+    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p, name, buffer, buffer_size);
     return err_no_error;
   }
 
@@ -948,7 +952,7 @@ int common_adios_read(int64_t fd_p, const char *name, void *buffer,
     adios_error(err_invalid_file_mode,
                 "read attempted on %s which was opened for write\n", fd->name);
 
-    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p);
+    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p, name, buffer, buffer_size);
     return adios_errno;
   }
 
@@ -970,11 +974,11 @@ int common_adios_read(int64_t fd_p, const char *name, void *buffer,
     adios_error(err_invalid_varname, "var %s in file %s not found on read\n",
                 name, fd->name);
 
-    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p);
+    ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p, name, buffer, buffer_size);
     return adios_errno;
   }
 
-  ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p);
+  ADIOST_CALLBACK_EXIT(adiost_event_read, fd_p, name, buffer, buffer_size);
   return adios_errno;
 }
 

--- a/src/core/common_adios.c
+++ b/src/core/common_adios.c
@@ -725,7 +725,7 @@ int common_adios_write(struct adios_file_struct *fd, struct adios_var_struct *v,
 #if defined(WITH_NCSU_TIMER) && defined(TIMER_LEVEL) && (TIMER_LEVEL <= 0)
     timer_start("adios_transform");
 #endif
-    ADIOST_CALLBACK_ENTER(adiost_event_transform, fd);
+    ADIOST_CALLBACK_ENTER(adiost_event_transform, (int64_t)fd);
     int success = common_adios_write_transform_helper(fd, v);
     if (success) {
       // Make it appear as if the user had supplied the transformed data
@@ -737,7 +737,7 @@ int common_adios_write(struct adios_file_struct *fd, struct adios_var_struct *v,
           adios_transform_plugin_primary_xml_alias(v->transform_type), v->name);
       // FIXME: Reverse the transform metadata and write raw data as usual
     }
-    ADIOST_CALLBACK_EXIT(adiost_event_transform, fd);
+    ADIOST_CALLBACK_EXIT(adiost_event_transform, (int64_t)fd);
 #if defined(WITH_NCSU_TIMER) && defined(TIMER_LEVEL) && (TIMER_LEVEL <= 0)
     timer_stop("adios_transform");
 #endif
@@ -1129,12 +1129,12 @@ int common_adios_close(struct adios_file_struct *fd) {
 #endif
   adios_errno = err_no_error;
 
-  ADIOST_CALLBACK_ENTER(adiost_event_close, fd);
+  ADIOST_CALLBACK_ENTER(adiost_event_close, (int64_t)fd);
   if (!fd) {
     adios_error(err_invalid_file_pointer,
                 "Invalid handle passed to adios_close\n");
 
-    ADIOST_CALLBACK_EXIT(adiost_event_close, fd);
+    ADIOST_CALLBACK_EXIT(adiost_event_close, (int64_t)fd);
     return adios_errno;
   }
 
@@ -1145,7 +1145,7 @@ int common_adios_close(struct adios_file_struct *fd) {
     timer_stop("adios_close");
     timer_stop("adios_open_to_close");
 #endif
-    ADIOST_CALLBACK_EXIT(adiost_event_close, fd);
+    ADIOST_CALLBACK_EXIT(adiost_event_close, (int64_t)fd);
     return 0;
   }
 
@@ -1460,7 +1460,7 @@ fd->current_pg->pg_start_in_file=%lld\n",
 // timer_reset_timers ();
 #endif
 
-  ADIOST_CALLBACK_EXIT(adiost_event_close, fd);
+  ADIOST_CALLBACK_EXIT(adiost_event_close, (int64_t)fd);
   return adios_errno;
 }
 

--- a/src/core/common_adios.c
+++ b/src/core/common_adios.c
@@ -616,7 +616,7 @@ int common_adios_write(struct adios_file_struct *fd, struct adios_var_struct *v,
 #if defined(WITH_NCSU_TIMER) && defined(TIMER_LEVEL) && (TIMER_LEVEL <= 0)
   timer_start("adios_write");
 #endif
-  ADIOST_CALLBACK_ENTER(adiost_event_write, fd);
+  ADIOST_CALLBACK_WRITE_ENTER(adiost_event_write, fd, v);
   adios_errno = err_no_error;
   struct adios_method_list_struct *m = fd->group->methods;
 
@@ -784,7 +784,7 @@ int common_adios_write(struct adios_file_struct *fd, struct adios_var_struct *v,
 #if defined(WITH_NCSU_TIMER) && defined(TIMER_LEVEL) && (TIMER_LEVEL <= 0)
   timer_stop("adios_write");
 #endif
-  ADIOST_CALLBACK_EXIT(adiost_event_write, fd);
+  ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
   // printf ("var: %s written %d\n", v->name, v->write_count);
   return adios_errno;
 }
@@ -794,10 +794,10 @@ int common_adios_write_byid(struct adios_file_struct *fd,
                             struct adios_var_struct *v, const void *var) {
   struct adios_method_list_struct *m = fd->group->methods;
 
-  ADIOST_CALLBACK_ENTER(adiost_event_write, fd);
+  ADIOST_CALLBACK_WRITE_ENTER(adiost_event_write, fd, v);
   adios_errno = err_no_error;
   if (m && m->next == NULL && m->method->m == ADIOS_METHOD_NULL) {
-    ADIOST_CALLBACK_EXIT(adiost_event_write, fd);
+    ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
     return adios_errno;
   }
 
@@ -834,7 +834,7 @@ int common_adios_write_byid(struct adios_file_struct *fd,
               err_no_memory,
               "In adios_write, cannot allocate %lld bytes to copy scalar %s\n",
               element_size, v->name);
-          ADIOST_CALLBACK_EXIT(adiost_event_write, fd);
+          ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
           return adios_errno;
         }
 
@@ -849,7 +849,7 @@ int common_adios_write_byid(struct adios_file_struct *fd,
               err_no_memory,
               "In adios_write, cannot allocate %lld bytes to copy string %s\n",
               element_size, v->name);
-          ADIOST_CALLBACK_EXIT(adiost_event_write, fd);
+          ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
           return adios_errno;
         }
         ((char *)v->adata)[element_size] = 0;
@@ -873,7 +873,7 @@ int common_adios_write_byid(struct adios_file_struct *fd,
     adios_copy_var_written(fd, v);
   }
 
-  ADIOST_CALLBACK_EXIT(adiost_event_write, fd);
+  ADIOST_CALLBACK_WRITE_EXIT(adiost_event_write, fd, v);
   return adios_errno;
 }
 

--- a/src/public/adiost_callback_api.h
+++ b/src/public/adiost_callback_api.h
@@ -20,6 +20,8 @@
 #define ADIOST_WEAK
 #endif
 
+#include "adios_types.h"
+
 /****************************************************************************
  * iteration macros - to be expanded by other macros in multiple places
  ****************************************************************************/
@@ -33,7 +35,7 @@
 macro(adiost_event_thread,                  adiost_thread_callback_t,      1) \
 macro(adiost_event_open,                    adiost_open_callback_t,        3) \
 macro(adiost_event_close,                   adiost_file_callback_t,        5) \
-macro(adiost_event_write,                   adiost_file_callback_t,        10) \
+macro(adiost_event_write,                   adiost_write_callback_t,       10) \
 macro(adiost_event_read,                    adiost_file_callback_t,        12) \
 macro(adiost_event_advance_step,            adiost_file_callback_t,        14) \
 macro(adiost_event_group_size,              adiost_group_size_callback_t,  51) \
@@ -97,6 +99,16 @@ typedef void (*adiost_open_callback_t)(
 typedef void (*adiost_file_callback_t)(
     int64_t file_descriptor, 
     adiost_event_type_t type);
+
+/* Events: adios_write */
+typedef void (*adiost_write_callback_t)(
+    int64_t file_descriptor, 
+    adiost_event_type_t type,
+    const char * name, 
+    enum ADIOS_DATATYPES data_type, 
+    const int ndims, 
+    const char * dims, 
+    const void * value);
 
 /* Events: adios_group_size */
 typedef void (*adiost_group_size_callback_t)(

--- a/src/public/adiost_callback_api.h
+++ b/src/public/adiost_callback_api.h
@@ -33,49 +33,78 @@
 
 /* For each event, specify the callback type and the enumeration value. */
 #define FOREACH_ADIOST_EVENT(macro) \
-macro(adiost_event_thread,                  adiost_thread_callback_t,      1) \
-macro(adiost_event_open,                    adiost_open_callback_t,        3) \
-macro(adiost_event_close,                   adiost_file_callback_t,        5) \
-macro(adiost_event_write,                   adiost_write_callback_t,       10) \
-macro(adiost_event_read,                    adiost_file_callback_t,        12) \
-macro(adiost_event_advance_step,            adiost_advance_step_callback_t,        14) \
-macro(adiost_event_group_size,              adiost_group_size_callback_t,  51) \
-macro(adiost_event_transform,               adiost_file_callback_t,        52) \
-macro(adiost_event_fp_send_finalize_msg,    adiost_file_callback_t,       102) \
-macro(adiost_event_fp_send_read_msg,        adiost_file_callback_t,       105) \
-macro(adiost_event_fp_add_var_to_read_msg,  adiost_file_callback_t,       106) \
-macro(adiost_event_fp_copy_buffer,          adiost_file_callback_t,       205) \
-macro(adiost_event_read_init_method,        adiost_read_init_method_callback_t, 300) \
-macro(adiost_event_read_finalize_method,    adiost_read_finalize_method_callback_t, 301) \
-macro(adiost_event_read_open,               adiost_read_open_callback_t, 302) \
-macro(adiost_event_read_open_file,          adiost_read_open_file_callback_t, 303) \
-macro(adiost_event_release_step,            adiost_file_callback_t, 304) \
-macro(adiost_event_inq_var,                 adiost_inq_var_callback_t, 305) \
-macro(adiost_event_inq_var_byid,            adiost_inq_var_byid_callback_t, 306) \
-macro(adiost_event_free_varinfo,            adiost_free_varinfo_callback_t, 307) \
-macro(adiost_event_inq_var_stat,            adiost_inq_var_stat_callback_t, 308) \
-macro(adiost_event_inq_var_blockinfo,       adiost_inq_var_blockinfo_callback_t, 309) \
-macro(adiost_event_selection_boundingbox,   adiost_selection_boundingbox_callback_t, 310) \
-macro(adiost_event_selection_points,        adiost_selection_points_callback_t, 311) \
-macro(adiost_event_selection_writeblock,    adiost_selection_writeblock_callback_t, 312) \
-macro(adiost_event_selection_auto,          adiost_selection_auto_callback_t, 313) \
-macro(adiost_event_selection_delete,        adiost_selection_delete_callback_t, 314) \
-macro(adiost_event_schedule_read,           adiost_schedule_read_callback_t, 315) \
-macro(adiost_event_schedule_read_byid,      adiost_schedule_read_byid_callback_t, 316) \
-macro(adiost_event_perform_reads,           adiost_perform_reads_callback_t, 317) \
-macro(adiost_event_check_reads,             adiost_check_reads_callback_t, 318) \
-macro(adiost_event_free_chunk,              adiost_free_chunk_callback_t, 319) \
-macro(adiost_event_get_attr,                adiost_get_attr_callback_t, 320) \
-macro(adiost_event_get_attr_byid,           adiost_get_attr_byid_callback_t, 321) \
-macro(adiost_event_type_to_string,          adiost_type_to_string_callback_t, 322) \
-macro(adiost_event_type_size,               adiost_type_size_callback_t, 323) \
-macro(adiost_event_get_grouplist,           adiost_get_grouplist_callback_t, 324) \
-macro(adiost_event_group_view,              adiost_group_view_callback_t, 325) \
-macro(adiost_event_stat_cov,                adiost_stat_cov_callback_t, 326) \
-macro(adiost_event_inq_mesh_byid,           adiost_inq_mesh_byid_callback_t, 328) \
-macro(adiost_event_free_meshinfo,           adiost_free_meshinfo_callback_t, 329) \
-macro(adiost_event_inq_var_meshinfo,        adiost_inq_var_meshinfo_callback_t, 330) \
-macro(adiost_event_library_shutdown,        adiost_callback_t,            999) \
+macro(adiost_event_thread,                 adiost_thread_callback_t,      1) \
+macro(adiost_event_init,                   adiost_init_callback_t,        2) \
+macro(adiost_event_open,                   adiost_open_callback_t,        3) \
+macro(adiost_event_close,                  adiost_file_callback_t,       5) \
+macro(adiost_event_finalize,               adiost_finalize_callback_t,    6) \
+macro(adiost_event_write,                  adiost_write_callback_t,       10) \
+macro(adiost_event_read,                   adiost_read_callback_t,        12) \
+macro(adiost_event_advance_step,           adiost_advance_step_callback_t,14) \
+macro(adiost_event_init_noxml,             adiost_init_noxml_callback_t,  20) \
+macro(adiost_event_set_max_buffer_size,    adiost_set_max_buffer_size_callback_t,  21) \
+macro(adiost_event_declare_group,          adiost_declare_group_callback_t,  22) \
+macro(adiost_event_define_var,             adiost_define_var_callback_t,  23) \
+macro(adiost_event_define_attribute,       adiost_define_attribute_callback_t,  24) \
+macro(adiost_event_define_attribute_byvalue, adiost_define_attribute_byvalue_callback_t,  25) \
+macro(adiost_event_set_transform,          adiost_set_transform_callback_t,  26) \
+macro(adiost_event_write_byid,             adiost_write_callback_t,  27) \
+macro(adiost_event_select_method,          adiost_select_method_callback_t,  28) \
+macro(adiost_event_expected_var_size,      adiost_expected_var_size_callback_t,  29) \
+macro(adiost_event_group_size,             adiost_group_size_callback_t,  51) \
+macro(adiost_event_transform,              adiost_file_callback_t,        52) \
+macro(adiost_event_define_schema_version,  adiost_define_schema_version_callback_t, 100) \
+macro(adiost_event_define_var_mesh,        adiost_define_var_mesh_callback_t, 101) \
+macro(adiost_event_define_var_centering,   adiost_define_var_centering_callback_t, 102) \
+macro(adiost_event_define_var_timesteps,   adiost_define_var_timesteps_callback_t, 103) \
+macro(adiost_event_define_var_timescale,   adiost_define_var_timescale_callback_t, 104) \
+macro(adiost_event_define_var_timeseriesformat, adiost_define_var_timeseriesformat_callback_t, 105) \
+macro(adiost_event_define_var_hyperslab,   adiost_define_var_hyperslab_callback_t, 106) \
+macro(adiost_event_define_mesh_timevarying, adiost_define_mesh_timevarying_callback_t, 107) \
+macro(adiost_event_define_mesh_timesteps,  adiost_define_mesh_timesteps_callback_t, 108) \
+macro(adiost_event_define_mesh_timescale,  adiost_define_mesh_timescale_callback_t, 109) \
+macro(adiost_event_define_mesh_timeseriesformat,  adiost_define_mesh_timeseriesformat_callback_t, 110) \
+macro(adiost_event_define_mesh_group,      adiost_define_mesh_group_callback_t, 111) \
+macro(adiost_event_define_mesh_file,       adiost_define_mesh_file_callback_t, 112) \
+macro(adiost_event_define_mesh_uniform,    adiost_define_mesh_uniform_callback_t, 113) \
+macro(adiost_event_define_mesh_rectilinear, adiost_define_mesh_rectilinear_callback_t, 114) \
+macro(adiost_event_define_mesh_structured, adiost_define_mesh_structured_callback_t, 115) \
+macro(adiost_event_define_mesh_unstructured, adiost_define_mesh_unstructured_callback_t, 116) \
+macro(adiost_event_fp_send_finalize_msg,   adiost_file_callback_t,       200) \
+macro(adiost_event_fp_send_read_msg,       adiost_file_callback_t,       201) \
+macro(adiost_event_fp_add_var_to_read_msg, adiost_file_callback_t,       202) \
+macro(adiost_event_fp_copy_buffer,         adiost_file_callback_t,       203) \
+macro(adiost_event_read_init_method,       adiost_read_init_method_callback_t, 300) \
+macro(adiost_event_read_finalize_method,   adiost_read_finalize_method_callback_t, 301) \
+macro(adiost_event_read_open,              adiost_read_open_callback_t, 302) \
+macro(adiost_event_read_open_file,         adiost_read_open_file_callback_t, 303) \
+macro(adiost_event_release_step,           adiost_file_callback_t, 304) \
+macro(adiost_event_inq_var,                adiost_inq_var_callback_t, 305) \
+macro(adiost_event_inq_var_byid,           adiost_inq_var_byid_callback_t, 306) \
+macro(adiost_event_free_varinfo,           adiost_free_varinfo_callback_t, 307) \
+macro(adiost_event_inq_var_stat,           adiost_inq_var_stat_callback_t, 308) \
+macro(adiost_event_inq_var_blockinfo,      adiost_inq_var_blockinfo_callback_t, 309) \
+macro(adiost_event_selection_boundingbox,  adiost_selection_boundingbox_callback_t, 310) \
+macro(adiost_event_selection_points,       adiost_selection_points_callback_t, 311) \
+macro(adiost_event_selection_writeblock,   adiost_selection_writeblock_callback_t, 312) \
+macro(adiost_event_selection_auto,         adiost_selection_auto_callback_t, 313) \
+macro(adiost_event_selection_delete,       adiost_selection_delete_callback_t, 314) \
+macro(adiost_event_schedule_read,          adiost_schedule_read_callback_t, 315) \
+macro(adiost_event_schedule_read_byid,     adiost_schedule_read_byid_callback_t, 316) \
+macro(adiost_event_perform_reads,          adiost_perform_reads_callback_t, 317) \
+macro(adiost_event_check_reads,            adiost_check_reads_callback_t, 318) \
+macro(adiost_event_free_chunk,             adiost_free_chunk_callback_t, 319) \
+macro(adiost_event_get_attr,               adiost_get_attr_callback_t, 320) \
+macro(adiost_event_get_attr_byid,          adiost_get_attr_byid_callback_t, 321) \
+macro(adiost_event_type_to_string,         adiost_type_to_string_callback_t, 322) \
+macro(adiost_event_type_size,              adiost_type_size_callback_t, 323) \
+macro(adiost_event_get_grouplist,          adiost_get_grouplist_callback_t, 324) \
+macro(adiost_event_group_view,             adiost_group_view_callback_t, 325) \
+macro(adiost_event_stat_cov,               adiost_stat_cov_callback_t, 326) \
+macro(adiost_event_inq_mesh_byid,          adiost_inq_mesh_byid_callback_t, 328) \
+macro(adiost_event_free_meshinfo,          adiost_free_meshinfo_callback_t, 329) \
+macro(adiost_event_inq_var_meshinfo,       adiost_inq_var_meshinfo_callback_t, 330) \
+macro(adiost_event_library_shutdown,       adiost_callback_t,            999) \
 
 #endif // #ifdef __ADIOST_CALLBACK_API_H__
 
@@ -113,8 +142,19 @@ typedef adiost_interface_fn_t (*adiost_function_lookup_t)(
 /* Events: adios_thread */
 typedef void (*adiost_thread_callback_t)(
     adiost_event_type_t type,
-    ADIOS_FILE * file_descriptor,
+    const ADIOS_FILE * file_descriptor,
     const char * thread_name
+);
+
+typedef void (*adiost_init_callback_t)(
+    adiost_event_type_t type,
+	const char * xml_fname,
+	MPI_Comm comm
+);
+
+typedef void (*adiost_finalize_callback_t)(
+    adiost_event_type_t type,
+	int proc_id
 );
 
 /* Events: adios_open */
@@ -123,7 +163,8 @@ typedef void (*adiost_open_callback_t)(
     int64_t file_descriptor,
     const char * group_name,
     const char * file_name,
-    const char * mode
+    const char * mode,
+	MPI_Comm comm
 );
 
 /* Events: adios_close, adios_read_begin...adios_write_end */
@@ -141,18 +182,229 @@ typedef void (*adiost_write_callback_t)(
     const char * dims, 
     const void * value);
 
+typedef void (*adiost_read_callback_t)(
+    adiost_event_type_t type,
+    int64_t file_descriptor,
+	const char * name,
+	const void * buffer,
+	uint64_t buffer_size
+);
+
 /* Events: adios_group_size */
 typedef void (*adiost_group_size_callback_t)(
     adiost_event_type_t type,
     int64_t file_descriptor,
     uint64_t data_size,
-    uint64_t total_size
+    const uint64_t * total_size
 );
 
 /* Events: adiost_event_library_shutdown */
 typedef void (*adiost_callback_t)(void);
 
-/* ----------- Events for Pooky/Pookie/Pukie! ------------- */
+/* ----------- No-XML Write API ------------- */
+
+typedef void (*adiost_init_noxml_callback_t)(
+    adiost_event_type_t type,
+    MPI_Comm comm
+);
+
+typedef void (*adiost_set_max_buffer_size_callback_t)(
+    adiost_event_type_t type,
+    uint64_t buffer_size
+);
+
+typedef void (*adiost_declare_group_callback_t)(
+    adiost_event_type_t type,
+    const int64_t * id,
+	const char * name,
+	const char  *time_index,
+	enum ADIOS_STATISTICS_FLAG stats
+);
+
+typedef void (*adiost_define_var_callback_t)(
+    adiost_event_type_t type,
+    int64_t group_id,
+	const char * name,
+	const char * path,
+	enum ADIOS_DATATYPES data_type,
+	const char * dimensions,
+	const char * global_dimensions,
+	const char * local_offsets
+);
+
+typedef void (*adiost_set_transform_callback_t)(
+    adiost_event_type_t type,
+    int64_t var_id,
+	const char * transform_type_str
+);
+
+typedef void (*adiost_define_attribute_callback_t)(
+    adiost_event_type_t type,
+	int64_t group,
+	const char * name,
+	const char * path,
+	enum ADIOS_DATATYPES data_type,
+	const char * value,
+	const char * var
+);
+
+typedef void (*adiost_define_attribute_byvalue_callback_t)(
+    adiost_event_type_t type,
+	int64_t group,
+	const char * name,
+	const char * path,
+	enum ADIOS_DATATYPES data_type,
+	int nelems,
+	const char * values
+);
+
+typedef void (*adiost_select_method_callback_t)(
+    adiost_event_type_t type,
+	int64_t group,
+	const char * method,
+	const char * parameters,
+	const char * base_path
+);
+
+typedef void (*adiost_expected_var_size_callback_t)(
+    adiost_event_type_t type,
+	int64_t var_id
+);
+
+/* ----------- No-XML Write API for viz ------------- */
+
+typedef void (*adiost_define_schema_version_callback_t)(
+    adiost_event_type_t type,
+	int64_t group_id,
+	const char * schema_version
+);
+
+typedef void (*adiost_define_var_mesh_callback_t)(
+    adiost_event_type_t type,
+	int64_t group_id,
+	const char * varname,
+	const char * meshname
+);
+
+typedef void (*adiost_define_var_centering_callback_t)(
+    adiost_event_type_t type,
+	int64_t group_id,
+	const char * varname,
+	const char * centering
+);
+
+typedef void (*adiost_define_var_timesteps_callback_t)(
+    adiost_event_type_t type,
+	const char * timesteps,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_var_timescale_callback_t)(
+    adiost_event_type_t type,
+	const char * timescale,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_var_timeseriesformat_callback_t)(
+    adiost_event_type_t type,
+	const char * timeseries,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_var_hyperslab_callback_t)(
+    adiost_event_type_t type,
+	const char * hyperslab,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_timevarying_callback_t)(
+    adiost_event_type_t type,
+	const char * timevarying,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_timesteps_callback_t)(
+    adiost_event_type_t type,
+	const char * timesteps,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_timescale_callback_t)(
+    adiost_event_type_t type,
+	const char * timescale,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_timeseriesformat_callback_t)(
+    adiost_event_type_t type,
+	const char * timesseries,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_group_callback_t)(
+    adiost_event_type_t type,
+	const char * group,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_file_callback_t)(
+    adiost_event_type_t type,
+	int64_t group_id,
+	const char * name,
+	const char * file
+);
+
+typedef void (*adiost_define_mesh_uniform_callback_t)(
+    adiost_event_type_t type,
+	const char * dimensions,
+	const char * origin,
+	const char * spacing,
+	const char * maximum,
+	const char * nspace,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_rectilinear_callback_t)(
+    adiost_event_type_t type,
+	const char * dimensions,
+	const char * coordinates,
+	const char * nspace,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_structured_callback_t)(
+    adiost_event_type_t type,
+	const char * dimensions,
+	const char * points,
+	const char * nspace,
+	int64_t group_id,
+	const char * name
+);
+
+typedef void (*adiost_define_mesh_unstructured_callback_t)(
+    adiost_event_type_t type,
+	const char * points,
+	const char * data,
+	const char * count,
+	const char * cell_type,
+	const char * npoints,
+	const char * nspace,
+	int64_t group_id,
+	const char * name
+);
+
+/* ----------- Read API ------------- */
 
 /* Events: adios_read_init_method */
 typedef void (*adiost_read_init_method_callback_t)(
@@ -175,7 +427,7 @@ typedef void (*adiost_read_open_callback_t)(
     MPI_Comm comm, 
 	enum ADIOS_LOCKMODE lock_mode,
     float timeout_sec,
-	ADIOS_FILE * file_descriptor
+	const ADIOS_FILE * file_descriptor
 );
 
 /* Events: adios_read_open_file */
@@ -184,13 +436,13 @@ typedef void (*adiost_read_open_file_callback_t)(
     const char * fname,
     enum ADIOS_READ_METHOD method, 
     MPI_Comm comm,
-	ADIOS_FILE * file_descriptor
+	const ADIOS_FILE * file_descriptor
 );
 
 /* Events: adios_advance_step */
 typedef void (*adiost_advance_step_callback_t)(
     adiost_event_type_t type,
-    ADIOS_FILE *fp,
+    const ADIOS_FILE *fp,
     int last,
     float timeout_sec
 );
@@ -208,20 +460,20 @@ typedef void (*adiost_inq_var_byid_callback_t)(
     adiost_event_type_t type,
     const ADIOS_FILE *fp,
     int varid,
-	ADIOS_VARINFO * varinfo
+	const ADIOS_VARINFO * varinfo
 );
 
 /* Events: adios_read_free_varinfo */
 typedef void (*adiost_free_varinfo_callback_t)(
     adiost_event_type_t type,
-	ADIOS_VARINFO * varinfo
+	const ADIOS_VARINFO * varinfo
 );
 
 /* Events: adios_read_inq_var_stat */
 typedef void (*adiost_inq_var_stat_callback_t)(
     adiost_event_type_t type,
     const ADIOS_FILE *fp,
-	ADIOS_VARINFO * varinfo,
+	const ADIOS_VARINFO * varinfo,
 	int per_prep_stat,
 	int per_block_stat
 );
@@ -230,7 +482,7 @@ typedef void (*adiost_inq_var_stat_callback_t)(
 typedef void (*adiost_inq_var_blockinfo_callback_t)(
     adiost_event_type_t type,
     const ADIOS_FILE *fp,
-	ADIOS_VARINFO * varinfo
+	const ADIOS_VARINFO * varinfo
 );
 
 /* Events: adios_read_selection_boundingbox */
@@ -239,7 +491,7 @@ typedef void (*adiost_selection_boundingbox_callback_t)(
     uint64_t ndim,
     const uint64_t *start,
     const uint64_t *count,
-	ADIOS_SELECTION * selection
+	const ADIOS_SELECTION * selection
 );
 
 /* Events: */
@@ -248,29 +500,29 @@ typedef void (*adiost_selection_points_callback_t)(
     uint64_t ndim,
     uint64_t npoints,
     const uint64_t *points,
-	ADIOS_SELECTION * container,
+	const ADIOS_SELECTION * container,
 	int free_points_on_delete,
-	ADIOS_SELECTION * selection
+	const ADIOS_SELECTION * selection
 );
 
 /* Events: */
 typedef void (*adiost_selection_writeblock_callback_t)(
     adiost_event_type_t type,
     int index,
-	ADIOS_SELECTION * selection
+	const ADIOS_SELECTION * selection
 );
 
 /* Events: */
 typedef void (*adiost_selection_auto_callback_t)(
     adiost_event_type_t type,
     char * hints,
-	ADIOS_SELECTION * selection
+	const ADIOS_SELECTION * selection
 );
 
 /* Events: */
 typedef void (*adiost_selection_delete_callback_t)(
     adiost_event_type_t type,
-	ADIOS_SELECTION * selection
+	const ADIOS_SELECTION * selection
 );
 
 /* Events: */
@@ -294,7 +546,7 @@ typedef void (*adiost_schedule_read_byid_callback_t)(
 	int from_steps,
 	int nsteps,
 	const char * param,
-	void * data
+	const void * data
 );
 
 /* Events: */
@@ -323,8 +575,8 @@ typedef void (*adiost_get_attr_callback_t)(
     const ADIOS_FILE *fp,
 	const char * attrname,
 	enum ADIOS_DATATYPES * datatypes,
-    int * size,
-	void **data
+    const int * size,
+	const void **data
 );
 
 /* Events: */
@@ -333,8 +585,8 @@ typedef void (*adiost_get_attr_byid_callback_t)(
     const ADIOS_FILE *fp,
 	int attrid,
 	enum ADIOS_DATATYPES * datatypes,
-    int * size,
-	void **data
+    const int * size,
+	const void **data
 );
 
 /* Events: */
@@ -346,7 +598,7 @@ typedef void (*adiost_type_to_string_callback_t)(
 /* Events: */
 typedef void (*adiost_type_size_callback_t)(
     adiost_event_type_t type,
-    void * dadta,
+    const void * dadta,
 	int size
 );
 
@@ -354,22 +606,22 @@ typedef void (*adiost_type_size_callback_t)(
 typedef void (*adiost_get_grouplist_callback_t)(
     adiost_event_type_t type,
     const ADIOS_FILE *fp,
-	char ***group_namelist
+	const char ***group_namelist
 );
 
 /* Events: */
 typedef void (*adiost_group_view_callback_t)(
     adiost_event_type_t type,
-    ADIOS_FILE *fp,
+    const ADIOS_FILE *fp,
 	int groupid
 );
 
 /* Events: */
 typedef void (*adiost_stat_cov_callback_t)(
     adiost_event_type_t type,
-    ADIOS_VARINFO * vix,
-	ADIOS_VARINFO * viy,
-	char * characteristic,
+    const ADIOS_VARINFO * vix,
+	const ADIOS_VARINFO * viy,
+	const char * characteristic,
 	uint32_t time_start,
 	uint32_t time_end,
 	uint32_t lag,
@@ -381,20 +633,20 @@ typedef void (*adiost_inq_mesh_byid_callback_t)(
     adiost_event_type_t type,
     const ADIOS_FILE *fp,
 	int meshid,
-	ADIOS_MESH * mesh
+	const ADIOS_MESH * mesh
 );
 
 /* Events: */
 typedef void (*adiost_free_meshinfo_callback_t)(
     adiost_event_type_t type,
-	ADIOS_MESH * mesh
+	const ADIOS_MESH * mesh
 );
 
 /* Events: */
 typedef void (*adiost_inq_var_meshinfo_callback_t)(
     adiost_event_type_t type,
     const ADIOS_FILE *fp,
-	ADIOS_VARINFO * varinfo
+	const ADIOS_VARINFO * varinfo
 );
 
 /****************************************************************************

--- a/src/public/adiost_callback_api.h
+++ b/src/public/adiost_callback_api.h
@@ -21,6 +21,7 @@
 #endif
 
 #include "adios_types.h"
+#include "adios_read.h"
 
 /****************************************************************************
  * iteration macros - to be expanded by other macros in multiple places
@@ -37,13 +38,43 @@ macro(adiost_event_open,                    adiost_open_callback_t,        3) \
 macro(adiost_event_close,                   adiost_file_callback_t,        5) \
 macro(adiost_event_write,                   adiost_write_callback_t,       10) \
 macro(adiost_event_read,                    adiost_file_callback_t,        12) \
-macro(adiost_event_advance_step,            adiost_file_callback_t,        14) \
+macro(adiost_event_advance_step,            adiost_advance_step_callback_t,        14) \
 macro(adiost_event_group_size,              adiost_group_size_callback_t,  51) \
 macro(adiost_event_transform,               adiost_file_callback_t,        52) \
 macro(adiost_event_fp_send_finalize_msg,    adiost_file_callback_t,       102) \
 macro(adiost_event_fp_send_read_msg,        adiost_file_callback_t,       105) \
 macro(adiost_event_fp_add_var_to_read_msg,  adiost_file_callback_t,       106) \
 macro(adiost_event_fp_copy_buffer,          adiost_file_callback_t,       205) \
+macro(adiost_event_read_init_method,        adiost_read_init_method_callback_t, 300) \
+macro(adiost_event_read_finalize_method,    adiost_read_finalize_method_callback_t, 301) \
+macro(adiost_event_read_open,               adiost_read_open_callback_t, 302) \
+macro(adiost_event_read_open_file,          adiost_read_open_file_callback_t, 303) \
+macro(adiost_event_release_step,            adiost_file_callback_t, 304) \
+macro(adiost_event_inq_var,                 adiost_inq_var_callback_t, 305) \
+macro(adiost_event_inq_var_byid,            adiost_inq_var_byid_callback_t, 306) \
+macro(adiost_event_free_varinfo,            adiost_free_varinfo_callback_t, 307) \
+macro(adiost_event_inq_var_stat,            adiost_inq_var_stat_callback_t, 308) \
+macro(adiost_event_inq_var_blockinfo,       adiost_inq_var_blockinfo_callback_t, 309) \
+macro(adiost_event_selection_boundingbox,   adiost_selection_boundingbox_callback_t, 310) \
+macro(adiost_event_selection_points,        adiost_selection_points_callback_t, 311) \
+macro(adiost_event_selection_writeblock,    adiost_selection_writeblock_callback_t, 312) \
+macro(adiost_event_selection_auto,          adiost_selection_auto_callback_t, 313) \
+macro(adiost_event_selection_delete,        adiost_selection_delete_callback_t, 314) \
+macro(adiost_event_schedule_read,           adiost_schedule_read_callback_t, 315) \
+macro(adiost_event_schedule_read_byid,      adiost_schedule_read_byid_callback_t, 316) \
+macro(adiost_event_perform_reads,           adiost_perform_reads_callback_t, 317) \
+macro(adiost_event_check_reads,             adiost_check_reads_callback_t, 318) \
+macro(adiost_event_free_chunk,              adiost_free_chunk_callback_t, 319) \
+macro(adiost_event_get_attr,                adiost_get_attr_callback_t, 320) \
+macro(adiost_event_get_attr_byid,           adiost_get_attr_byid_callback_t, 321) \
+macro(adiost_event_type_to_string,          adiost_type_to_string_callback_t, 322) \
+macro(adiost_event_type_size,               adiost_type_size_callback_t, 323) \
+macro(adiost_event_get_grouplist,           adiost_get_grouplist_callback_t, 324) \
+macro(adiost_event_group_view,              adiost_group_view_callback_t, 325) \
+macro(adiost_event_stat_cov,                adiost_stat_cov_callback_t, 326) \
+macro(adiost_event_inq_mesh_byid,           adiost_inq_mesh_byid_callback_t, 328) \
+macro(adiost_event_free_meshinfo,           adiost_free_meshinfo_callback_t, 329) \
+macro(adiost_event_inq_var_meshinfo,        adiost_inq_var_meshinfo_callback_t, 330) \
 macro(adiost_event_library_shutdown,        adiost_callback_t,            999) \
 
 #endif // #ifdef __ADIOST_CALLBACK_API_H__
@@ -81,15 +112,15 @@ typedef adiost_interface_fn_t (*adiost_function_lookup_t)(
 
 /* Events: adios_thread */
 typedef void (*adiost_thread_callback_t)(
-    int64_t file_descriptor,
     adiost_event_type_t type,
+    ADIOS_FILE * file_descriptor,
     const char * thread_name
 );
 
 /* Events: adios_open */
 typedef void (*adiost_open_callback_t)(
-    int64_t file_descriptor,
     adiost_event_type_t type,
+    int64_t file_descriptor,
     const char * group_name,
     const char * file_name,
     const char * mode
@@ -97,13 +128,13 @@ typedef void (*adiost_open_callback_t)(
 
 /* Events: adios_close, adios_read_begin...adios_write_end */
 typedef void (*adiost_file_callback_t)(
-    int64_t file_descriptor, 
-    adiost_event_type_t type);
+    adiost_event_type_t type,
+    int64_t file_descriptor);
 
 /* Events: adios_write */
 typedef void (*adiost_write_callback_t)(
-    int64_t file_descriptor, 
     adiost_event_type_t type,
+    int64_t file_descriptor, 
     const char * name, 
     enum ADIOS_DATATYPES data_type, 
     const int ndims, 
@@ -112,14 +143,259 @@ typedef void (*adiost_write_callback_t)(
 
 /* Events: adios_group_size */
 typedef void (*adiost_group_size_callback_t)(
-    int64_t file_descriptor,
     adiost_event_type_t type,
+    int64_t file_descriptor,
     uint64_t data_size,
     uint64_t total_size
 );
 
 /* Events: adiost_event_library_shutdown */
 typedef void (*adiost_callback_t)(void);
+
+/* ----------- Events for Pooky/Pookie/Pukie! ------------- */
+
+/* Events: adios_read_init_method */
+typedef void (*adiost_read_init_method_callback_t)(
+    adiost_event_type_t type,
+    enum ADIOS_READ_METHOD method, 
+    MPI_Comm comm, 
+    const char * parameters
+);
+
+/* Events: adios_read_finalize_method */
+typedef void (*adiost_read_finalize_method_callback_t)(
+    adiost_event_type_t type,
+    enum ADIOS_READ_METHOD method 
+);
+
+/* Events: adios_read_open */
+typedef void (*adiost_read_open_callback_t)(
+    adiost_event_type_t type,
+    enum ADIOS_READ_METHOD method, 
+    MPI_Comm comm, 
+	enum ADIOS_LOCKMODE lock_mode,
+    float timeout_sec,
+	ADIOS_FILE * file_descriptor
+);
+
+/* Events: adios_read_open_file */
+typedef void (*adiost_read_open_file_callback_t)(
+    adiost_event_type_t type,
+    const char * fname,
+    enum ADIOS_READ_METHOD method, 
+    MPI_Comm comm,
+	ADIOS_FILE * file_descriptor
+);
+
+/* Events: adios_advance_step */
+typedef void (*adiost_advance_step_callback_t)(
+    adiost_event_type_t type,
+    ADIOS_FILE *fp,
+    int last,
+    float timeout_sec
+);
+
+/* Events: adios_read_inq_var */
+typedef void (*adiost_inq_var_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+    const char * varname,
+	ADIOS_VARINFO * varinfo
+);
+
+/* Events: adios_read_inq_var_byid */
+typedef void (*adiost_inq_var_byid_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+    int varid,
+	ADIOS_VARINFO * varinfo
+);
+
+/* Events: adios_read_free_varinfo */
+typedef void (*adiost_free_varinfo_callback_t)(
+    adiost_event_type_t type,
+	ADIOS_VARINFO * varinfo
+);
+
+/* Events: adios_read_inq_var_stat */
+typedef void (*adiost_inq_var_stat_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	ADIOS_VARINFO * varinfo,
+	int per_prep_stat,
+	int per_block_stat
+);
+
+/* Events: adios_read_inq_var_blockinfo */
+typedef void (*adiost_inq_var_blockinfo_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	ADIOS_VARINFO * varinfo
+);
+
+/* Events: adios_read_selection_boundingbox */
+typedef void (*adiost_selection_boundingbox_callback_t)(
+    adiost_event_type_t type,
+    uint64_t ndim,
+    const uint64_t *start,
+    const uint64_t *count,
+	ADIOS_SELECTION * selection
+);
+
+/* Events: */
+typedef void (*adiost_selection_points_callback_t)(
+    adiost_event_type_t type,
+    uint64_t ndim,
+    uint64_t npoints,
+    const uint64_t *points,
+	ADIOS_SELECTION * container,
+	int free_points_on_delete,
+	ADIOS_SELECTION * selection
+);
+
+/* Events: */
+typedef void (*adiost_selection_writeblock_callback_t)(
+    adiost_event_type_t type,
+    int index,
+	ADIOS_SELECTION * selection
+);
+
+/* Events: */
+typedef void (*adiost_selection_auto_callback_t)(
+    adiost_event_type_t type,
+    char * hints,
+	ADIOS_SELECTION * selection
+);
+
+/* Events: */
+typedef void (*adiost_selection_delete_callback_t)(
+    adiost_event_type_t type,
+	ADIOS_SELECTION * selection
+);
+
+/* Events: */
+typedef void (*adiost_schedule_read_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	const ADIOS_SELECTION * selection,
+	const char * varname,
+	int from_steps,
+	int nsteps,
+	const char * param,
+	void * data
+);
+
+/* Events: */
+typedef void (*adiost_schedule_read_byid_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	const ADIOS_SELECTION * selection,
+	int varid,
+	int from_steps,
+	int nsteps,
+	const char * param,
+	void * data
+);
+
+/* Events: */
+typedef void (*adiost_perform_reads_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	int blocking
+);
+
+/* Events: */
+typedef void (*adiost_check_reads_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	ADIOS_VARCHUNK **chunk
+);
+
+/* Events: */
+typedef void (*adiost_free_chunk_callback_t)(
+    adiost_event_type_t type,
+	ADIOS_VARCHUNK *chunk
+);
+
+/* Events: */
+typedef void (*adiost_get_attr_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	const char * attrname,
+	enum ADIOS_DATATYPES * datatypes,
+    int * size,
+	void **data
+);
+
+/* Events: */
+typedef void (*adiost_get_attr_byid_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	int attrid,
+	enum ADIOS_DATATYPES * datatypes,
+    int * size,
+	void **data
+);
+
+/* Events: */
+typedef void (*adiost_type_to_string_callback_t)(
+    adiost_event_type_t type,
+    const char * name
+);
+
+/* Events: */
+typedef void (*adiost_type_size_callback_t)(
+    adiost_event_type_t type,
+    void * dadta,
+	int size
+);
+
+/* Events: */
+typedef void (*adiost_get_grouplist_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	char ***group_namelist
+);
+
+/* Events: */
+typedef void (*adiost_group_view_callback_t)(
+    adiost_event_type_t type,
+    ADIOS_FILE *fp,
+	int groupid
+);
+
+/* Events: */
+typedef void (*adiost_stat_cov_callback_t)(
+    adiost_event_type_t type,
+    ADIOS_VARINFO * vix,
+	ADIOS_VARINFO * viy,
+	char * characteristic,
+	uint32_t time_start,
+	uint32_t time_end,
+	uint32_t lag,
+	double correlation
+);
+
+/* Events: */
+typedef void (*adiost_inq_mesh_byid_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	int meshid,
+	ADIOS_MESH * mesh
+);
+
+/* Events: */
+typedef void (*adiost_free_meshinfo_callback_t)(
+    adiost_event_type_t type,
+	ADIOS_MESH * mesh
+);
+
+/* Events: */
+typedef void (*adiost_inq_var_meshinfo_callback_t)(
+    adiost_event_type_t type,
+    const ADIOS_FILE *fp,
+	ADIOS_VARINFO * varinfo
+);
 
 /****************************************************************************
  * ADIOST API

--- a/src/read/read_bp.c
+++ b/src/read/read_bp.c
@@ -4299,6 +4299,7 @@ static ADIOS_VARCHUNK * read_var_wb (const ADIOS_FILE * fp, read_request * r)
 // NCSU - Timer series analysis, correlation
 double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characteristic, uint32_t time_start, uint32_t time_end, uint32_t lag)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
     int i,j;
 
     double avg_x = 0.0, avg_y = 0.0, avg_lag = 0.0;
@@ -4308,6 +4309,7 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     if (vix == NULL)
     {
         fprintf(stderr, "Variable not defined\n");
+        ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
         return 0;
     }
 
@@ -4315,6 +4317,7 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     if ((vix->timedim < 0) && (viy->timedim < 0))
     {
         fprintf(stderr, "Covariance must involve timeseries data\n");
+        ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
         return 0;
     }
 
@@ -4326,6 +4329,7 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     { //global covariance
         if(viy == NULL) {
             fprintf(stderr, "Must have two variables for global covariance\n");
+            ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
             return 0;
         }
 
@@ -4344,6 +4348,7 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
             if(! (time_end+lag) > min)
             {
                 fprintf(stderr, "Must leave enough timesteps for lag\n");
+                ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
                 return 0;
             }
 
@@ -4418,8 +4423,10 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
             else
             {
                 fprintf (stderr, "Unknown characteristic\n");
+                ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
                 return 0;
             }
+            ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
             return cov / (sqrt (var_x) * sqrt (var_lag));
         }
         else
@@ -4491,14 +4498,17 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
             else
             {
                 fprintf (stderr, "Unknown characteristic\n");
+                ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
                 return 0;
             }
+            ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
             return cov / (sqrt (var_x) * sqrt (var_y));
         }
     }
     else
     {
         fprintf (stderr, "Time values out of bounds\n");
+        ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
         return 0;
     }
 }
@@ -4507,6 +4517,7 @@ double adios_stat_cor (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
 //covariance(x,y) = sum(i=1,..N) [(x_1 - x_mean)(y_i - y_mean)]/N
 double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characteristic, uint32_t time_start, uint32_t time_end, uint32_t lag)
 {
+    ADIOST_CALLBACK_ENTER(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
     int i,j;
 
     double avg_x = 0.0, avg_y = 0.0, avg_lag = 0.0;
@@ -4515,6 +4526,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     if (vix == NULL)
     {
         fprintf(stderr, "Variable not defined\n");
+        ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
         return 0;
     }
 
@@ -4522,6 +4534,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     if ((vix->timedim < 0) && (viy->timedim < 0))
     {
         fprintf(stderr, "Covariance must involve timeseries data\n");
+        ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
         return 0;
     }
 
@@ -4533,6 +4546,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     { //global covariance
         if(viy == NULL) {
             fprintf(stderr, "Must have two variables for global covariance\n");
+            ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
             return 0;
         }
 
@@ -4551,6 +4565,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
             if(! (time_end+lag) > min)
             {
                 fprintf(stderr, "Must leave enough timesteps for lag\n");
+                ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
                 return 0;
             }
 
@@ -4601,6 +4616,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
             else
             {
                 fprintf (stderr, "Unknown characteristic\n");
+                ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
                 return 0;
             }
         }
@@ -4657,6 +4673,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
             else
             {
                 fprintf (stderr, "Unknown characteristic\n");
+                ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
                 return 0;
             }
         }
@@ -4665,6 +4682,7 @@ double adios_stat_cov (ADIOS_VARINFO * vix, ADIOS_VARINFO * viy, char * characte
     {
         fprintf (stderr, "Time values out of bounds\n");
     }
+    ADIOST_CALLBACK_EXIT(adiost_event_stat_cov, vix, viy, characteristic, time_start, time_end, lag);
     return cov;
 }
 #endif

--- a/src/read/read_flexpath.c
+++ b/src/read/read_flexpath.c
@@ -1081,7 +1081,7 @@ setup_flexpath_vars(FMField *f, int *num, int nattrs)
 void
 send_finalize_msg(flexpath_reader_file *fp)
 {
-    ADIOST_CALLBACK_ENTER(adiost_event_fp_send_finalize_msg, fp);
+    ADIOST_CALLBACK_ENTER(adiost_event_fp_send_finalize_msg, (int64_t)fp);
     int i; 
     if((fp->rank / fp->num_bridges) == 0)
     {
@@ -1105,13 +1105,13 @@ send_finalize_msg(flexpath_reader_file *fp)
             EVsubmit(fp->bridges[send_to].finalize_source, &msg, NULL);
         }
     }
-    ADIOST_CALLBACK_EXIT(adiost_event_fp_send_finalize_msg, fp);
+    ADIOST_CALLBACK_EXIT(adiost_event_fp_send_finalize_msg, (int64_t)fp);
 }
 
 static void
 send_read_msg(flexpath_reader_file *fp, int index, int use_condition)
 {
-    ADIOST_CALLBACK_ENTER(adiost_event_fp_send_read_msg, fp);
+    ADIOST_CALLBACK_ENTER(adiost_event_fp_send_read_msg, (int64_t)fp);
     //Initial sanity check
     if(index >= fp->num_sendees)
     {
@@ -1147,13 +1147,13 @@ send_read_msg(flexpath_reader_file *fp, int index, int use_condition)
 	CMCondition_wait(fp_read_data->cm, msg->condition);
 	fp_verbose(fp, "Done with WAIT\n");
     }
-    ADIOST_CALLBACK_EXIT(adiost_event_fp_send_read_msg, fp);
+    ADIOST_CALLBACK_EXIT(adiost_event_fp_send_read_msg, (int64_t)fp);
 }
 
 void
 add_var_to_read_message(flexpath_reader_file *fp, int destination, char *varname)
 {
-    ADIOST_CALLBACK_ENTER(adiost_event_fp_add_var_to_read_msg, fp);
+    ADIOST_CALLBACK_ENTER(adiost_event_fp_add_var_to_read_msg, (int64_t)fp);
         int i = 0;
         int found = 0;
         int index = -1;
@@ -1189,7 +1189,7 @@ add_var_to_read_message(flexpath_reader_file *fp, int destination, char *varname
 	if (!fp->bridges[destination].opened) {
 	    fp->bridges[destination].opened = 1;
 	}
-    ADIOST_CALLBACK_EXIT(adiost_event_fp_add_var_to_read_msg, fp);
+    ADIOST_CALLBACK_EXIT(adiost_event_fp_add_var_to_read_msg, (int64_t)fp);
 }
 
 /********** EVPath Handlers **********/

--- a/src/write/adios_flexpath.c
+++ b/src/write/adios_flexpath.c
@@ -982,7 +982,7 @@ set_format(struct adios_group_struct *t,
 // copies buffer zeroing out pointers to arrays 
 void *copy_buffer_without_array(void *buffer, FlexpathWriteFileData *fileData)
 {
-    ADIOST_CALLBACK_ENTER(adiost_event_fp_copy_buffer, fileData);
+    ADIOST_CALLBACK_ENTER(adiost_event_fp_copy_buffer, (int64_t)fileData);
     char *temp = (char *)malloc(fileData->fm->size);
     memcpy(temp, buffer, fileData->fm->size);
     FMField *f = fileData->fm->format[0].field_list;
@@ -993,7 +993,7 @@ void *copy_buffer_without_array(void *buffer, FlexpathWriteFileData *fileData)
         }
         f++;
     }
-    ADIOST_CALLBACK_EXIT(adiost_event_fp_copy_buffer, fileData);
+    ADIOST_CALLBACK_EXIT(adiost_event_fp_copy_buffer, (int64_t)fileData);
     return temp;
 }
 

--- a/src/write/adios_mpi_amr.c
+++ b/src/write/adios_mpi_amr.c
@@ -950,7 +950,7 @@ void * adios_mpi_amr_do_open_thread (void * param)
                      td->md->subfile_name, e);
     }
 
-    ADIOST_CALLBACK_ENTER(adiost_event_thread, NULL, __func__);
+    ADIOST_CALLBACK_EXIT(adiost_event_thread, NULL, __func__);
     return NULL;
 }
 


### PR DESCRIPTION
I went through the ADIOS 1.12 documentation and added ADIOST callbacks for all relevant (not deprecated) adios_* API calls discussed in the documentation.