### PR TITLE
fix read of zero size transformed data

### DIFF
--- a/src/transforms/adios_transform_blosc_read.c
+++ b/src/transforms/adios_transform_blosc_read.c
@@ -87,6 +87,10 @@ adios_datablock * adios_transform_blosc_pg_reqgroup_completed(adios_transform_re
     uint64_t input_size = (uint64_t)completed_pg_reqgroup->raw_var_length;
     char* input_buff = (char*)(completed_pg_reqgroup->subreqs->data);
 
+    // empty chunk in process group
+    if(completed_pg_reqgroup->transform_metadata == NULL)
+        return NULL;
+
     adiosBloscSize_t num_chunks = *((adiosBloscSize_t*)completed_pg_reqgroup->transform_metadata);
     adiosBloscSize_t compressed_size_last_chunk = *((adiosBloscSize_t*)(completed_pg_reqgroup->transform_metadata + sizeof(adiosBloscSize_t)));
 

--- a/src/transforms/adios_transform_bzip2_read.c
+++ b/src/transforms/adios_transform_bzip2_read.c
@@ -64,7 +64,11 @@ adios_datablock * adios_transform_bzip2_pg_reqgroup_completed(adios_transform_re
 {
     uint64_t compressed_size = (uint64_t)completed_pg_reqgroup->raw_var_length;
     void* compressed_data = completed_pg_reqgroup->subreqs->data;
-    
+
+    // empty chunk in process group
+    if(completed_pg_reqgroup->transform_metadata == NULL)
+        return NULL;
+
     uint64_t uncompressed_size_meta = *((uint64_t*)completed_pg_reqgroup->transform_metadata);
     char compress_ok = *((char*)(completed_pg_reqgroup->transform_metadata + sizeof(uint64_t)));
 

--- a/src/transforms/adios_transform_lz4_read.c
+++ b/src/transforms/adios_transform_lz4_read.c
@@ -87,6 +87,10 @@ adios_datablock * adios_transform_lz4_pg_reqgroup_completed(adios_transform_read
     uint64_t input_size = (uint64_t) completed_pg_reqgroup->raw_var_length;
     char* input_buff = (char*) (completed_pg_reqgroup->subreqs->data);
 
+    // empty chunk in process group
+    if(completed_pg_reqgroup->transform_metadata == NULL)
+        return NULL;
+
     // number of full chunks
     adiosLz4Size_t num_chunks = *((adiosLz4Size_t*) completed_pg_reqgroup->transform_metadata);
     // compressed size of the last chunk

--- a/src/transforms/adios_transform_zlib_read.c
+++ b/src/transforms/adios_transform_zlib_read.c
@@ -61,7 +61,11 @@ adios_datablock * adios_transform_zlib_pg_reqgroup_completed(adios_transform_rea
 {
     uint64_t compressed_size = (uint64_t)completed_pg_reqgroup->raw_var_length;
     void* compressed_data = completed_pg_reqgroup->subreqs->data;
-    
+
+    // empty chunk in process group
+    if(completed_pg_reqgroup->transform_metadata == NULL)
+        return NULL;
+
     uint64_t uncompressed_size_meta = *((uint64_t*)completed_pg_reqgroup->transform_metadata);
     char compress_ok = *((char*)(completed_pg_reqgroup->transform_metadata + sizeof(uint64_t)));
 


### PR DESCRIPTION
fix #161

Avoid null pointer dereferencing during the read of transformed data of size zero
  - bzip2
  - lz4
  - blosc
  - zlib

Zero-sized data occurs regularly on read of parallel files that store unstructured data such as particles. In domain decomposition over MPI ranks, some ranks do not hold particles at a certain point in time and due to that write zero particles (into a N>0 sized global variable).