### PR TITLE
Fix clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,7 @@ CHECK_FUNCTION_EXISTS(clock_get_time HAVE_CLOCK_GET_TIME)
 
 # Check if clockid_t type exist
 include(CheckTypeSize)
+SET(CMAKE_EXTRA_INCLUDE_FILES "time.h")
 CHECK_TYPE_SIZE("clockid_t" CLOCKID_T)
 
 # Define if you have CRAY_PMI.

--- a/src/core/adiosf.c
+++ b/src/core/adiosf.c
@@ -530,7 +530,7 @@ void FC_FUNC_(adios_declare_group, ADIOS_DECLARE_GROUP)
     *err = adios_errno;
 }
 
-int FC_FUNC_(adios_set_time_aggregation, ADIOS_SET_TIME_AGGREGATION)
+void FC_FUNC_(adios_set_time_aggregation, ADIOS_SET_TIME_AGGREGATION)
         (int64_t * group_id, int64_t * buffersize, int64_t * sync_group_id, int * err)
 {
     adios_errno = err_no_error;

--- a/src/mxml/mxml-2.9/mxml-string.c
+++ b/src/mxml/mxml-2.9/mxml-string.c
@@ -20,6 +20,8 @@
 
 #include "config.h"
 
+#include <stdarg.h>
+#include <stddef.h>
 
 /*
  * The va_copy macro is part of C99, but many compilers don't implement it.

--- a/src/mxml/mxml-2.9/mxml-string.c
+++ b/src/mxml/mxml-2.9/mxml-string.c
@@ -80,6 +80,8 @@ _mxml_strdup(const char *s)		/* I - String to duplicate */
 }
 #endif /* !HAVE_STRDUP */
 
+/* forward declaration needed for _mxml_strdupf */
+char * _mxml_vstrdupf(const char *, va_list);
 
 /*
  * '_mxml_strdupf()' - Format and duplicate a string.

--- a/src/mxml/mxml-2.9/mxml.h
+++ b/src/mxml/mxml-2.9/mxml.h
@@ -30,6 +30,8 @@
 #  include <string.h>
 #  include <ctype.h>
 #  include <errno.h>
+#  include <stdarg.h>
+#  include <stddef.h>
 
 
 /*


### PR DESCRIPTION
The ADIOS master fails to compile on Apple Clang systems.
```
$ mpicc --version
Apple LLVM version 9.0.0 (clang-900.0.38)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```