### PR TITLE
Fix const correctness and warnings

### DIFF
--- a/doc/manual/adios_noxml_write_api.tex
+++ b/doc/manual/adios_noxml_write_api.tex
@@ -518,7 +518,7 @@ mesh from the attributes stored in ADIOS files.
 This function defines which version of schema is used for visualization in ADIOS.
 
 \begin{lstlisting}[alsolanguage=C,caption={},label={}]
-int adios_define_schema_version (int64_t group_id, char * schema_version)
+int adios_define_schema_version (int64_t group_id, const char * schema_version)
 \end{lstlisting}
 
 Input:
@@ -792,7 +792,7 @@ call adios_define_mesh_group ("experiment", m_adios_group, "uniformmesh")
 This API indicates a external file where mesh is defined.
 
 \begin{lstlisting}[alsolanguage=C,caption={},label={}]
-int adios_define_mesh_file(int64_t group_id, char * name, char * file)
+int adios_define_mesh_file(int64_t group_id, const char * name, const char * file)
 \end{lstlisting}
 
 Input:
@@ -812,11 +812,11 @@ call adios_define_mesh_file (m_adios_group, "uniformmesh", "uniformmesh.bp")
 This function defines a uniform mesh. For not requried attributes in this function, please use 0 instead.
 
 \begin{lstlisting}[alsolanguage=Fortran,caption={},label={}]
-int adios_define_mesh_uniform (char * dimensions,
-                               char * origin,
-                               char * spacing,
-                               char * maximum,
-                               char * nspace,
+int adios_define_mesh_uniform (const char * dimensions,
+                               const char * origin,
+                               const char * spacing,
+                               const char * maximum,
+                               const char * nspace,
                                int64_t group_id,
                                const char * name)
 \end{lstlisting}
@@ -843,9 +843,9 @@ call adios_define_mesh_uniform ("10,10,10", "0,1,0.5", "0.5, 0.3, 1", 0,
 This function defines a rectilinear mesh. For not requried attributes in this function, please use 0 instead.
 
 \begin{lstlisting}[alsolanguage=Fortran,caption={},label={}]
-int adios_define_mesh_rectilinear (char * dimensions,
-                                   char * coordinates,
-                                   char * nspace,
+int adios_define_mesh_rectilinear (const char * dimensions,
+                                   const char * coordinates,
+                                   const char * nspace,
                                    int64_t group_id,
                                    const char * name)
 \end{lstlisting}
@@ -870,9 +870,9 @@ call adios_define_mesh_rectilinear ("10,10,10", "X,Y", "2", m_adios_group,
 This function defines a structured mesh. For not requried attributes in this function, please use 0 instead.
 
 \begin{lstlisting}[alsolanguage=Fortran,caption={},label={}]
-int adios_define_mesh_structured (char * dimensions,
-                                  char * points,
-                                  char * nspace,
+int adios_define_mesh_structured (const char * dimensions,
+                                  const char * points,
+                                  const char * nspace,
                                   int64_t group_id,
                                   const char * name)
 \end{lstlisting}
@@ -897,12 +897,12 @@ call adios_define_mesh_structured ("10,10,10", "X,Y", "2", m_adios_group,
 This function defines a unstructured mesh. For not requried attributes in this function, please use 0 instead.
 
 \begin{lstlisting}[alsolanguage=Fortran,caption={},label={}]
-int adios_define_mesh_unstructured (char * points,
-                                    char * data,
-                                    char * count,
-                                    char * cell_type,
-                                    char * npoints,
-                                    char * nspace,
+int adios_define_mesh_unstructured (const char * points,
+                                    const char * data,
+                                    const char * count,
+                                    const char * cell_type,
+                                    const char * npoints,
+                                    const char * nspace,
                                     int64_t group_id,
                                     const char * name)
 \end{lstlisting}

--- a/src/core/adios.c
+++ b/src/core/adios.c
@@ -466,10 +466,10 @@ void adios_timing_write_xml (int64_t fd_p, const char* filename)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int adios_define_schema_version (int64_t group_id, char * schema_version)
+int adios_define_schema_version (int64_t group_id, const char * schema_version)
 {
     struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_schema_version (g, schema_version);
+    return adios_common_define_schema_version (g, (char *)schema_version);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -485,9 +485,9 @@ int adios_define_var_centering (int64_t group_id, const char * varname, const ch
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int adios_define_mesh_file (int64_t group_id, char * name, char * file)
+int adios_define_mesh_file (int64_t group_id, const char * name, const char * file)
 {
-    return  adios_common_define_mesh_file (group_id, name, file);
+    return  adios_common_define_mesh_file (group_id, (char *)name, (char *)file);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -521,87 +521,87 @@ int adios_define_var_hyperslab ( const char * hyperslab, int64_t group_id, const
 ///////////////////////////////////////////////////////////////////////////////
 int adios_define_mesh_timevarying (const char * timevarying, int64_t group_id, const char * name)
 {
-    return adios_common_define_mesh_timeVarying (timevarying, group_id, name);
+    return adios_common_define_mesh_timeVarying ((char *)timevarying, group_id, name);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int adios_define_mesh_timesteps (const char * timesteps, int64_t group_id, const char * name)
 {
     struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_timeSteps (timesteps, g, name);
+    return adios_common_define_mesh_timeSteps ((char *)timesteps, g, name);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int adios_define_mesh_timescale (const char * timescale, int64_t group_id, const char * name)
 {
     struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_timeScale (timescale, g, name);
+    return adios_common_define_mesh_timeScale ((char *)timescale, g, (char *)name);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int adios_define_mesh_timeseriesformat (const char * timeseries, int64_t group_id, const char * name)
 {
     struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_timeSeriesFormat (timeseries, g, name);
+    return adios_common_define_mesh_timeSeriesFormat ((char *)timeseries, g, (char *)name);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int adios_define_mesh_group (const char * group, int64_t group_id, const char * name)
 {
-    return adios_common_define_mesh_group (group_id, name, group);
+    return adios_common_define_mesh_group (group_id, (char *)name, (char *)group);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int adios_define_mesh_uniform (char * dimensions,
-                               char * origin,
-                               char * spacing,
-                               char * maximum,
-                               char * nspace,
+int adios_define_mesh_uniform (const char * dimensions,
+                               const char * origin,
+                               const char * spacing,
+                               const char * maximum,
+                               const char * nspace,
                                int64_t group_id,
                                const char * name
                               )
 {
 //    struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_uniform (dimensions, origin, spacing, maximum, nspace, name, group_id);
+    return adios_common_define_mesh_uniform ((char *)dimensions, (char *)origin, (char *)spacing, (char *)maximum, (char *)nspace, (char *)name, group_id);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int adios_define_mesh_rectilinear (char * dimensions,
-                                   char * coordinates,
-                                   char * nspace,
+int adios_define_mesh_rectilinear (const char * dimensions,
+                                   const char * coordinates,
+                                   const char * nspace,
                                    int64_t group_id,
                                    const char * name
                                   )
 {
 //    struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_rectilinear (dimensions, coordinates, nspace, name, group_id);
+    return adios_common_define_mesh_rectilinear ((char *)dimensions, (char *)coordinates, (char *)nspace, (char *)name, group_id);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int adios_define_mesh_structured (char * dimensions,
-                                  char * points,
-                                  char * nspace,
+int adios_define_mesh_structured (const char * dimensions,
+                                  const char * points,
+                                  const char * nspace,
                                   int64_t group_id,
                                   const char * name
                                  )
 {
 //    struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_structured (dimensions, nspace, points, name, group_id);
+    return adios_common_define_mesh_structured ((char *)dimensions, (char *)nspace, (char *)points, (char *)name, group_id);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int adios_define_mesh_unstructured (char * points,
-                                    char * data,
-                                    char * count,
-                                    char * cell_type,
-                                    char * npoints,
-                                    char * nspace,
+int adios_define_mesh_unstructured (const char * points,
+                                    const char * data,
+                                    const char * count,
+                                    const char * cell_type,
+                                    const char * npoints,
+                                    const char * nspace,
                                     int64_t group_id,
                                     const char * name
                                    )
 {
 //    struct adios_group_struct * g = (struct adios_group_struct *) group_id;
-    return adios_common_define_mesh_unstructured (points, data, count, cell_type, nspace, npoints, name, group_id);
+    return adios_common_define_mesh_unstructured ((char *)points, (char *)data, (char *)count, (char *)cell_type, (char *)nspace, (char *)npoints, (char *)name, group_id);
 }
 
 ADIOS_AVAILABLE_WRITE_METHODS * adios_available_write_methods()

--- a/src/core/bp_utils.c
+++ b/src/core/bp_utils.c
@@ -164,7 +164,6 @@ int get_time (struct adios_index_var_struct_v1 * v, int step)
  */
 int get_time_from_pglist(struct bp_index_pg_struct_v1 * pgs, int step)
 {
-    int i = 0;
     int prev_ti = 0, counter = 0;
 
     while (pgs != NULL)
@@ -361,7 +360,6 @@ int bp_open (const char * fname,
     // Broadcast the index which may be bigger than 2GB, so do it in chunks
     uint64_t bytes_sent = 0;
     int32_t to_send = 0;
-    int r, err;
 
     while (bytes_sent < footer_size)
     {

--- a/src/public/adios.h
+++ b/src/public/adios.h
@@ -193,7 +193,7 @@ void adios_timing_write_xml (int64_t fd_p, const char* filename);
 // no-xml schema API
 // Define adios schema version
 // The function implements the same as "schema version="1.1 ""in xml
-int adios_define_schema_version (int64_t group_id, char * schema_version);
+int adios_define_schema_version (int64_t group_id, const char * schema_version);
 
 // Assign mesh to a variable
 // The function implements the same as "var name="Var1" mesh="meshname" " in xml 
@@ -202,8 +202,8 @@ int adios_define_var_mesh(int64_t group_id, const char * varname, const char * m
 // Define centering of the variable value onto the mesh, centering is "cell" or "point"
 int adios_define_var_centering(int64_t group_id, const char * varname, const char * centering);
 
-// Define a external file where mesh variables are written 
-int adios_define_mesh_file(int64_t group_id, char * name, char * file);
+// Define a external file where mesh variables are written
+int adios_define_mesh_file(int64_t group_id, const char * name, const char * file);
 
 // The time-­steps points to time variables using steps, starting from step 0
 int adios_define_var_timesteps (const char * timesteps, int64_t group_id, const char * name);
@@ -237,38 +237,38 @@ int adios_define_mesh_group (const char * group, int64_t group_id, const char * 
 
 // Defines a uniform mesh
 // For not requried attributes in this function, please use 0 instead
-int adios_define_mesh_uniform (char * dimensions, 
-                               char * origin, 
-                               char * spacing, 
-                               char * maximum, 
-                               char * nspace,
+int adios_define_mesh_uniform (const char * dimensions,
+                               const char * origin,
+                               const char * spacing,
+                               const char * maximum,
+                               const char * nspace,
                                int64_t group_id,
                                const char * name);
 
 // Defines a rectilinear mesh
 // For not requried attributes in this function, please use 0 instead
-int adios_define_mesh_rectilinear (char * dimensions, 
-                                   char * coordinates,
-                                   char * nspace,
+int adios_define_mesh_rectilinear (const char * dimensions,
+                                   const char * coordinates,
+                                   const char * nspace,
                                    int64_t group_id,
                                    const char * name);
 
 // Defines a structured mesh
 // For not requried attributes in this function, please use 0 instead
-int adios_define_mesh_structured (char * dimensions, 
-                                  char * points,
-                                  char * nspace,
+int adios_define_mesh_structured (const char * dimensions,
+                                  const char * points,
+                                  const char * nspace,
                                   int64_t group_id,
                                   const char * name);
 
 // Define an unstructured mesh
 // For not requried attributes in this function, please use 0 instead
-int adios_define_mesh_unstructured (char * points,
-                                    char * data, 
-                                    char * count, 
-                                    char * cell_type,
-                                    char * npoints,
-                                    char * nspace,
+int adios_define_mesh_unstructured (const char * points,
+                                    const char * data,
+                                    const char * count,
+                                    const char * cell_type,
+                                    const char * npoints,
+                                    const char * nspace,
                                     int64_t group_id,
                                     const char * name);
 

--- a/tests/C/flexpath_tests/global_range_select/reader.c
+++ b/tests/C/flexpath_tests/global_range_select/reader.c
@@ -26,7 +26,7 @@
 
 int main(int argc, char **argv)
 {
-    int rank, j;
+    int rank;
     int NX, NY;
     int writer_size;
     double *t;

--- a/tests/C/flexpath_tests/global_range_select/writer.c
+++ b/tests/C/flexpath_tests/global_range_select/writer.c
@@ -21,7 +21,6 @@
 /*************************************************************/
 int main(int argc, char **argv)
 {
-    char filename[256];
     int rank, size, i;
     int NX = 40;
     int NY = 1;

--- a/tests/suite/programs/steps_write.c
+++ b/tests/suite/programs/steps_write.c
@@ -15,7 +15,6 @@ int main (int argc, char ** argv)
 {
 	char        filename [256];
 	int         rank, size, i, j, step, block;
-        int         Offset; 
 
 	int         NX = 2; // number of records written per step per process
         int         Width=20;

--- a/tests/suite/programs/zerolength.c
+++ b/tests/suite/programs/zerolength.c
@@ -115,7 +115,6 @@ int write_data (char * transformdef)
     double      *t;
     /* ADIOS variables declarations for matching gwrite_temperature.ch */
     int         it, i, r;
-    uint64_t    adios_groupsize, adios_totalsize;
 
     if (!rank) printf ("------- Write blocks to file %s -------\n", fname);
     // We will have "nsteps * number of processes" blocks
@@ -191,7 +190,7 @@ int write_data (char * transformdef)
 
 void print_written_info()
 {
-    int s, r, b;
+    int s, r;
     printf ("\n------- Information recorded on rank 0 (read will compare to this info)  --------\n");
     for (s = 0; s < nsteps; s++) {
         printf ("Step %d:\n", s);

--- a/tests/test_src/read_points_3d.c
+++ b/tests/test_src/read_points_3d.c
@@ -383,7 +383,6 @@ int read_points ()
 
     ADIOS_SELECTION *pts;
     uint64_t start[100];
-    uint64_t count[100];
     ADIOS_SELECTION *box;
     uint64_t boxstart[3];
     uint64_t boxcount[3];


### PR DESCRIPTION
A number of public API function signatures use `char*` for C strings that aren't modified. This change allows `std::string.c_str()` and string literals to be used in C++ without a const cast for every downstream API call.

I also cleaned up a few unused variable warnings.