### PR TITLE
serial adios_open with parallel lib

### DIFF
--- a/src/core/adios_internals_mxml.c
+++ b/src/core/adios_internals_mxml.c
@@ -2173,8 +2173,9 @@ int adios_parse_config (const char * config, MPI_Comm comm)
     char * buffer = NULL;
     //#if HAVE_MPI
     int buffer_size = 0;
-    int rank;
-    MPI_Comm_rank (comm, &rank);
+    int rank = 0;
+    if (comm != MPI_COMM_NULL)
+        MPI_Comm_rank (comm, &rank);
     init_comm = comm;
     if (rank == 0)
     {


### PR DESCRIPTION
Fix a runtime error in the following situation:

when a user compiles a serial program against the parallel ADIOS libs, there are two ways to use ADIOS without the need to start the app with `mpiexec`:

a) use the moc library instead
b) pass `MPI_COMM_NULL` as communicator

I need the last case in my application but still `adios_open` calls a single `MPI_Comm_rank` which aborts the application.

This check (as it is done in many other places) fixes it.