### PR TITLE
Numpy: Scalar Attributes Warning

### DIFF
--- a/wrappers/numpy/adios.pyx
+++ b/wrappers/numpy/adios.pyx
@@ -1613,7 +1613,7 @@ cdef class var(dict):
         adios_selection_delete(sel)
 
         if (var.ndim == 0):
-            return np.asscalar(var)
+            return var.item()
         else:
             return var
 

--- a/wrappers/numpy/adios_mpi.pyx
+++ b/wrappers/numpy/adios_mpi.pyx
@@ -1611,7 +1611,7 @@ cdef class var(dict):
         adios_selection_delete(sel)
 
         if (var.ndim == 0):
-            return np.asscalar(var)
+            return var.item()
         else:
             return var
 


### PR DESCRIPTION
Upgrade the conversion of returned scalar attributes to the recommended usage in numpy.

In Numpy 1.16 and newer, the old usage throws a warning of the form ( https://github.com/numpy/numpy/pull/12123 )
```
DeprecationWarning: np.asscalar(a) is deprecated since NumPy v1.16, use a.item() instead
```

It is likely this will be removed in Numpy 1.18 and newer, so let us fix this right away.

[`ndarray.item()`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.item.html) is available since a long time/always, so that is a save change.