### PR TITLE
ZFP: Support API 0.5.1+

### DIFF
--- a/src/transforms/adios_transform_zfp_common.h
+++ b/src/transforms/adios_transform_zfp_common.h
@@ -146,7 +146,7 @@ static void zfp_initialize(void* array, struct zfp_buffer* zbuff)
 			zbuff->error = true;
 			return;
 		}
-	       	zfp_stream_set_accuracy(zbuff->zstream, tol, zbuff->type);
+	       	zfp_stream_set_accuracy(zbuff->zstream, tol);
 	}
 	else if (zbuff->mode == 1) 	// precision
 	{
@@ -172,7 +172,7 @@ static void zfp_initialize(void* array, struct zfp_buffer* zbuff)
 		tol = (uint) ct;
 
 
-		zfp_stream_set_precision(zbuff->zstream, tol, zbuff->type);
+		zfp_stream_set_precision(zbuff->zstream, tol);
 	}
 	else if (zbuff->mode == 2) 	// rate
 	{


### PR DESCRIPTION
In ZFP 0.5.1 (latest: 0.5.5), the public API changed slightly. In order to ease maintainance for ADIOS2, let's make ADIOS1 support these newer ZFP releases as well.

Fix #203

Note: this drops support for ZFP 0.5.0 or older.