### PR TITLE
fix configure.ac/autotools issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,8 @@ ACX_MPI([], [AC_MSG_ERROR([could not find mpi library for C])])
 if test -z "${HAVE_MPI_TRUE}"; then
     AC_LANG(C++)
     ACX_MPI([], [AC_MSG_ERROR([could not find mpi library for C++])])
-else
-    AC_DEFINE(HAVE_MPI,0,[Don not have MPI to build parallel libraries])
 fi
+AM_CONDITIONAL([HAVE_MPI], [test -z "${HAVE_MPI_TRUE}"])
 
 AC_ARG_ENABLE(fortran,
     [AS_HELP_STRING([--disable-fortran],[disable building Fortran libraries.])])


### PR DESCRIPTION
For whatever reason, it only causes trouble on some systems, but one is supposed
to use AM_CONDITIONAL for conditionals used in Makefile.am