### PR TITLE
Need include "netcdf.h" before include "netcdf_par.h" since it define…

### DIFF
--- a/src/write/adios_nc4.c
+++ b/src/write/adios_nc4.c
@@ -18,8 +18,9 @@
 #include "core/adios_transport_hooks.h"
 #include "core/adios_internals.h"
 #include "core/util.h"
-#include "netcdf_par.h"
 #include "netcdf.h"
+#include "netcdf_par.h"
+
 
 #include "nssi/io_timer.h"
 


### PR DESCRIPTION
…s EXTERNL in recent NetCDF releases