### PR TITLE
gcc-14: fix configure test error

### DIFF
--- a/config/ac_nc4par.m4
+++ b/config/ac_nc4par.m4
@@ -120,11 +120,12 @@ else
         AC_TRY_COMPILE(
             [#include "mpi.h"
              #include "netcdf.h"
+             #include "netcdf_par.h"
             ],
             [int ncid;
              MPI_Info info;
              MPI_Comm comm;
-             nc_create_par("a.nc", NC_NOCLOBBER|NC_MPIIO|NC_NETCDF4, comm, info, ncid);
+             nc_create_par("a.nc", NC_NOCLOBBER|NC_MPIIO|NC_NETCDF4, comm, info, &ncid);
              nc_close(ncid);
             ],
             [AC_MSG_RESULT(yes)],


### PR DESCRIPTION
```
configure:26495: /home/balay/petsc/arch-ci-linux-pkgs-cxx-mlib/bin/mpicc -c -Wno-lto-type-mismatch -Wno-stringop-overflow -g -O -I/home/balay/petsc/arch-ci-linux-pkgs-cxx-mlib/include -I/home/balay/petsc/arch-ci-linux-pkgs-cxx-mlib conftest.c >&5 conftest.c: In function 'main':
conftest.c:67:14: error: implicit declaration of function 'nc_create_par'; did you mean 'nc__create_mp'? [-Wimplicit-function-declaration]
   67 |              nc_create_par("a.nc", NC_NOCLOBBER|NC_MPIIO|NC_NETCDF4, comm, info, ncid);
      |              ^~~~~~~~~~~~~
      |              nc__create_mp
```